### PR TITLE
Add manual pipeline using repo secrets

### DIFF
--- a/.github/workflows/manual_post.yml
+++ b/.github/workflows/manual_post.yml
@@ -1,0 +1,32 @@
+name: Manual Post to Telegram
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Install tools
+        run: |
+          rustup component add clippy rustfmt
+          cargo install cargo-machete
+
+      - name: Build and run
+        env:
+          TELOXIDE_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          cargo fmt --all
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo machete
+          cargo test
+          cargo run --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,12 @@ async fn main() -> anyhow::Result<()> {
     let jobs = hh_client.fetch_jobs().await?;
 
     let token = std::env::var("TELOXIDE_TOKEN").unwrap_or_default();
-    let chat_id = std::env::var("TELEGRAM_CHAT_ID").unwrap_or_default();
+    let raw_chat_id = std::env::var("TELEGRAM_CHAT_ID").unwrap_or_default();
+    let chat_id = if raw_chat_id.starts_with("-100") {
+        raw_chat_id
+    } else {
+        format!("-100{}", raw_chat_id)
+    };
     let bot = TelegramBot::new(token, chat_id);
 
     let message = format!("Found {} Rust jobs", jobs.len());


### PR DESCRIPTION
## Summary
- use repository secrets for manual Telegram workflow
- ensure chat ID uses `-100` prefix automatically

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo machete`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686d611df7cc8332a2f9df7d2ac52e3d