### PR TITLE
Fix manual workflow action

### DIFF
--- a/.github/workflows/manual_post.yml
+++ b/.github/workflows/manual_post.yml
@@ -11,9 +11,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: actions/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
 
       - name: Install tools
         run: |


### PR DESCRIPTION
## Summary
- fix step to use `actions-rs/toolchain` instead of the missing `actions/setup-rust`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686d72e5db488332bf9e68e8eea6c70a