### PR TITLE
Add license and config docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+TELEGRAM_CHAT_ID=your_channel_id_here

--- a/.github/workflows/manual_post.yml
+++ b/.github/workflows/manual_post.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build and run
         env:
-          TELOXIDE_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
         run: |
           cargo fmt --all

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 qqrm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ This project collects daily job postings related to the Rust programming languag
 ## Documentation
 - [Project architecture](docs/README.md)
 - [Publication state storage](docs/TECHNICAL_DETAILS.md)
+
+## Configuration
+The bot expects two environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token |
+| `TELEGRAM_CHAT_ID` | ID of the channel to post jobs |
+
+Create a `.env` file using [`.env.example`](.env.example) as a template.
+
+## License
+This project is licensed under the [MIT](LICENSE) license.

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -1,7 +1,6 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct Job {
     pub id: String,
     pub name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use rust_hh_feed::hh;
 use rust_hh_feed::state;
 use rust_hh_feed::telegram;
 
+use anyhow::Context;
 use chrono::Utc;
 use state::{load_posted_jobs, save_posted_jobs};
 use std::path::Path;
@@ -12,8 +13,10 @@ async fn main() -> anyhow::Result<()> {
     let hh_client = hh::HhClient::new();
     let jobs = hh_client.fetch_jobs().await?;
 
-    let token = std::env::var("TELOXIDE_TOKEN").unwrap_or_default();
-    let raw_chat_id = std::env::var("TELEGRAM_CHAT_ID").unwrap_or_default();
+    let token = std::env::var("TELEGRAM_BOT_TOKEN")
+        .context("TELEGRAM_BOT_TOKEN environment variable not set")?;
+    let raw_chat_id = std::env::var("TELEGRAM_CHAT_ID")
+        .context("TELEGRAM_CHAT_ID environment variable not set")?;
     let chat_id = if raw_chat_id.starts_with("-100") {
         raw_chat_id
     } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,8 +24,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    #[tokio::test]
-    async fn load_and_save_cycle() {
+    #[test]
+    fn load_and_save_cycle() {
         let path = PathBuf::from("test_posted_jobs.json");
         let mut map = PostedJobs::new();
         map.insert("1".into(), "2024-07-08".into());


### PR DESCRIPTION
## Summary
- provide MIT license file
- add `.env.example` with required variables
- document environment variables and license in README
- remove unused attribute from `Job`
- validate env vars with error context
- simplify state test
- rename Telegram token variable to `TELEGRAM_BOT_TOKEN`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo machete`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686d7a3eeea88332981c80c05162cac8