### PR TITLE
Remove remote configuration instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@
 - After making any changes, run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.
 - Fix every issue reported by these commands before committing or submitting pull requests.
 - A pull request is complete only when formatting, linting, tests, and `cargo machete` all succeed.
-- Configure the remote `origin` as `https://github.com/qqrm/rust-hh-feed`.
 - Read all Markdown (`*.md`) files from the `.docs` directory before starting work. Markdown in tests can be ignored.
 - Avoid committed dead code; remove unused functions or feature-gate them.
 


### PR DESCRIPTION
## Summary
- clean up AGENTS instructions by deleting the line about configuring the `origin`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686d8c9bb1888332a420b81f6b30caad