### PR TITLE
Implement manual mode flag

### DIFF
--- a/.github/workflows/manual_post.yml
+++ b/.github/workflows/manual_post.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          MANUAL_MODE: true
         run: |
           cargo fmt --all
           cargo clippy --all-targets --all-features -- -D warnings

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ This project collects daily job postings related to the Rust programming languag
 - [Publication state storage](docs/TECHNICAL_DETAILS.md)
 
 ## Configuration
-The bot expects two environment variables:
+The bot expects a few environment variables:
 
 | Variable | Purpose |
-|----------|---------|
+|----------|---------------------------------------------------------|
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token |
 | `TELEGRAM_CHAT_ID` | ID of the channel to post jobs |
+| `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
 
 Create a `.env` file using [`.env.example`](.env.example) as a template.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ use state::{load_posted_jobs, save_posted_jobs};
 use std::path::Path;
 use telegram::TelegramBot;
 
+/// Environment variable that enables manual mode.
+const MANUAL_MODE_VAR: &str = "MANUAL_MODE";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let hh_client = hh::HhClient::new();
@@ -33,7 +36,16 @@ async fn main() -> anyhow::Result<()> {
             .entry(job.id)
             .or_insert_with(|| Utc::now().date_naive().to_string());
     }
-    save_posted_jobs(Path::new("data/posted_jobs.json"), &posted)?;
+
+    let manual_mode = std::env::var(MANUAL_MODE_VAR)
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if !manual_mode {
+        save_posted_jobs(Path::new("data/posted_jobs.json"), &posted)?;
+    } else {
+        println!("Manual mode enabled - not saving state");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add optional MANUAL_MODE environment variable in README
- honor MANUAL_MODE in main.rs and skip saving state when set
- pass MANUAL_MODE to manual_post workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo machete`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686d8c6d5e4083328590ea97a1fce493