### PR TITLE
Add per-job Telegram posting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ async fn main() -> anyhow::Result<()> {
 
     let message = format!("Found {jobs_len} Rust jobs", jobs_len = jobs.len());
     bot.send_message(&message).await?;
+    for job in &jobs {
+        bot.send_message(&job.url).await?;
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
 
     let mut posted = load_posted_jobs(Path::new("data/posted_jobs.json"))?;
     for job in jobs {

--- a/tests/telegram.rs
+++ b/tests/telegram.rs
@@ -1,0 +1,18 @@
+use mockito::{mock, server_url};
+use reqwest::StatusCode;
+use rust_hh_feed::telegram::TelegramBot;
+
+#[tokio::test]
+async fn send_message_returns_status() {
+    let token = "test".to_string();
+    let chat_id = "123".to_string();
+    let path = format!("/bot{token}/sendMessage");
+    let _m = mock("POST", path.as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .create();
+
+    let bot = TelegramBot::with_base_url(token, chat_id, server_url());
+    let status = bot.send_message("hi").await.unwrap();
+    assert_eq!(status, StatusCode::OK);
+}


### PR DESCRIPTION
## Summary
- update `TelegramBot` to accept custom base URL and return status
- send each job URL with delay in `main`
- cover Telegram posting with a test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686d8c681fd4833290af6960ee84ee80