### PR TITLE
Make CI logs quieter

### DIFF
--- a/.github/workflows/daily_post.yml
+++ b/.github/workflows/daily_post.yml
@@ -26,9 +26,10 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          CARGO_TERM_PROGRESS_WHEN: never
         run: |
           cargo fmt --all
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --quiet --all-targets --all-features -- -D warnings
           cargo machete
-          cargo test
-          cargo run --release
+          cargo test --quiet
+          cargo run --release --quiet

--- a/.github/workflows/manual_post.yml
+++ b/.github/workflows/manual_post.yml
@@ -26,9 +26,10 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
           MANUAL_MODE: true
+          CARGO_TERM_PROGRESS_WHEN: never
         run: |
           cargo fmt --all
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --quiet --all-targets --all-features -- -D warnings
           cargo machete
-          cargo test
-          cargo run --release
+          cargo test --quiet
+          cargo run --release --quiet

--- a/README.md
+++ b/README.md
@@ -31,5 +31,17 @@ The bot expects a few environment variables:
 
 Create a `.env` file using [`.env.example`](.env.example) as a template.
 
+## Quiet CI Logs
+When running CI workflows you can suppress crate download and compilation
+messages by adding `--quiet` to the Cargo commands. For example:
+
+```
+cargo clippy --quiet --all-targets --all-features -- -D warnings
+cargo test --quiet
+cargo run --release --quiet
+```
+
+This keeps the logs short while still printing warnings and errors.
+
 ## License
 This project is licensed under the [MIT](LICENSE) license.


### PR DESCRIPTION
## Summary
- reduce cargo output in GitHub workflows
- document how to run cargo in quiet mode

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686d8fa4b2f48332a9dfb28f8fa3f67d