### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -1,0 +1,29 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install tools
+        run: |
+          rustup component add clippy rustfmt
+          cargo install cargo-machete
+
+      - name: Run
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          CARGO_TERM_PROGRESS_WHEN: never
+        run: cargo run --release --quiet


### PR DESCRIPTION
## Summary
- add `.github/workflows/manual_release.yml` for on-demand releases
- keep only running the bot in this workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo machete`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686d9257838083328186cefced8ca10a