### PR TITLE
Cancel actions for merged PRs

### DIFF
--- a/.github/workflows/cancel_on_merge.yml
+++ b/.github/workflows/cancel_on_merge.yml
@@ -1,0 +1,36 @@
+name: Cancel Jobs on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel running workflows for PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = '${{ github.event.pull_request.head.ref }}';
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+                status: 'in_progress'
+              }
+            );
+            for (const run of runs) {
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }
+


### PR DESCRIPTION
## Summary
- add workflow `cancel_on_merge.yml` to stop running jobs once a PR is merged

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`
- `cargo install cargo-machete`


------
https://chatgpt.com/codex/tasks/task_e_686d96fd36548332baa04bbf2511f41f