### PR TITLE
Save state using POSTED_JOBS_PATH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(false);
 
     if !manual_mode {
-        save_posted_jobs(Path::new("data/posted_jobs.json"), &posted)?;
+        save_posted_jobs(Path::new(&path), &posted)?;
     } else {
         println!("Manual mode enabled - not saving state");
     }

--- a/tests/main_manual.rs
+++ b/tests/main_manual.rs
@@ -4,7 +4,6 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
-#[ignore]
 fn main_manual_mocked() {
     let _hh_mock = mock("GET", "/vacancies")
         .match_query(mockito::Matcher::Any)
@@ -14,6 +13,7 @@ fn main_manual_mocked() {
         .create();
 
     let _tg_mock = mock("POST", "/bottoken/sendMessage")
+        .expect(2)
         .with_status(200)
         .create();
 


### PR DESCRIPTION
## Summary
- persist job state using `POSTED_JOBS_PATH` variable
- run `main_manual_mocked` test by default and expect two sendMessage calls

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686d9b58cc848332ad29cb4fa6a44d5e