### PR TITLE
Убрал лишние println в hh.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "chrono",
+ "log",
  "mockito",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+log = "0.4"
 
 [dev-dependencies]
 mockito = "0.31"

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -30,7 +30,7 @@ impl HhClient {
 
     pub async fn fetch_jobs(&self) -> Result<Vec<Job>, reqwest::Error> {
         let url = format!("{}/vacancies", self.base_url);
-        println!("Requesting jobs from {url}");
+        log::debug!("Requesting jobs from {url}");
         let resp = self
             .client
             .get(&url)
@@ -47,19 +47,19 @@ impl HhClient {
             .await?
             .json::<serde_json::Value>()
             .await?;
-        println!("Raw response: {resp}");
+        log::debug!("Raw response: {resp}");
 
         let items = resp.get("items");
         if let Some(array) = items.and_then(|v| v.as_array()) {
-            println!("Found {} items in response", array.len());
+            log::debug!("Found {} items in response", array.len());
         } else {
-            println!("No items field found in response");
+            log::debug!("No items field found in response");
         }
 
         let jobs = items
             .and_then(|v| serde_json::from_value::<Vec<Job>>(v.clone()).ok())
             .unwrap_or_default();
-        println!("Parsed {} jobs", jobs.len());
+        log::debug!("Parsed {} jobs", jobs.len());
         Ok(jobs)
     }
 }


### PR DESCRIPTION
## Изменения
- подключён crate `log`
- `println!` в `HhClient::fetch_jobs` заменены на `log::debug!`
- обновлён `Cargo.lock`

## Проверки
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686da2c44a4c8332b914977e5d1df322