### PR TITLE
Add release workflow with binary upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release Binary
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        uses: ./.github/actions/setup-rust
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build release
+        run: cargo build --release --quiet
+      - name: Upload binary
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest
+          files: target/release/rust-hh-feed
+          allow_updates: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Additional workflows automate repository maintenance:
 
 - `pr_cleanup.yml` cancels running CI jobs and deletes the branch after a pull request is merged.
 - `manual_release.yml` allows manual execution of the bot through the GitHub UI.
+ 
+
+## Release Binary
+A push to the `main` branch updates the `latest` release with a freshly built executable. Only one file, `rust-hh-feed`, is kept in the release. Download it with:
+
+```
+curl -L https://github.com/<owner>/<repo>/releases/latest/download/rust-hh-feed -o rust-hh-feed
+```
 
 ## License
 This project is licensed under the [MIT](LICENSE) license.


### PR DESCRIPTION
## Summary
- add `release.yml` to publish the binary on pushes to `main`
- document the release binary and how to download it

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686da2b7f698833281911eed2953c945