### PR TITLE
Add cargo cache to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,15 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup-rust
 
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run checks
         run: |
           cargo fmt --all

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -10,6 +10,15 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup-rust
 
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -18,6 +18,15 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build and run
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- speed up builds by caching cargo registry, git, and target directories
- add the cache step to CI, posting, and manual release workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686da2b1670083329c29392d62aa9a47