### PR TITLE
Remove job count notification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,6 @@ async fn main() -> anyhow::Result<()> {
         TelegramBot::new(token, chat_id)
     };
 
-    let message = format!("Found {jobs_len} Rust jobs", jobs_len = jobs.len());
-    bot.send_message(&message).await?;
     for job in &jobs {
         bot.send_message(&job.url).await?;
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;

--- a/tests/main_manual.rs
+++ b/tests/main_manual.rs
@@ -13,7 +13,7 @@ fn main_manual_mocked() {
         .create();
 
     let _tg_mock = mock("POST", "/bottoken/sendMessage")
-        .expect(2)
+        .expect(1)
         .with_status(200)
         .create();
 


### PR DESCRIPTION
## Summary
- drop the message about the number of jobs
- adjust test expectations

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686da314a47483328f79244dde0e8544