### PR TITLE
Update pr_cleanup workflow permissions

### DIFF
--- a/.github/workflows/pr_cleanup.yml
+++ b/.github/workflows/pr_cleanup.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   actions: write
+  contents: write
 
 jobs:
   cleanup:


### PR DESCRIPTION
## Summary
- allow the PR cleanup workflow to push updates by granting `contents: write`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686da7192a608332bff75cf297a43127