### PR TITLE
Fix auto-merge workflow permissions

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   enable-auto-merge:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## Summary
- grant write permissions for contents and pull requests in `auto_merge.yml`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686e38b94b148332b114ed46c99cfdb0