### PR TITLE
Hourly posting schedule

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -2,7 +2,7 @@ name: Post to Telegram
 
 on:
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-hh-feed
 
-This project collects daily job postings related to the Rust programming language from HeadHunter and posts them to a Telegram channel.
+This project collects hourly job postings related to the Rust programming language from HeadHunter and posts them to a Telegram channel.
 You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 
 ## Main Features
@@ -8,7 +8,7 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 - Query the hh.ru API for fresh vacancies using the keyword "Rust".
 - Filter vacancies where "Rust" appears in the title or key requirements.
 - Publish the results to a Telegram channel via a bot.
-- Schedule the process to run once per day.
+- Schedule the process to run every hour.
 
 ## Components
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Uses the Bot API to send messages.
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
-   - Runs the update process once per day, typically via GitHub Actions.
+   - Runs the update process once per hour, typically via GitHub Actions.
 
 ## Data Flow
 1. The scheduler initiates the task.

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -32,7 +32,8 @@ impl HhClient {
     pub async fn fetch_jobs(&self) -> Result<Vec<Job>, reqwest::Error> {
         let url = format!("{}/vacancies", self.base_url);
         let to = Utc::now();
-        let from = to - Duration::hours(24);
+        // Narrow the search window to a single hour because the bot runs every hour.
+        let from = to - Duration::hours(1);
         log::debug!("Requesting jobs from {url}");
         let resp = self
             .client


### PR DESCRIPTION
## Summary
- query hourly and reduce API time window accordingly
- schedule `post.yml` workflow to run every hour
- update documentation about the new schedule

## Testing
- `cargo clippy --quiet --all-targets --all-features -- -D warnings`
- `cargo machete`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686e8a796c408332aea4030c7e863676