### PR TITLE
Fix scheduled posts to use production channel

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build and run
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           CARGO_TERM_PROGRESS_WHEN: never
           MANUAL_MODE: ${{ github.event_name == 'workflow_dispatch' }}
         run: |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The bot expects a few environment variables:
 | `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
 | `RUN_INTEGRATION` | Set to `true` to run the bot during CI |
 
+During continuous integration the bot posts to the development channel
+configured by `DEV_TELEGRAM_CHAT_ID`. Scheduled runs and manual releases use
+`TELEGRAM_CHAT_ID` to post to the production channel.
+
 Set the `RUST_LOG` environment variable to control the logging level, for
 example `RUST_LOG=info`.
 


### PR DESCRIPTION
## Summary
- route scheduled Telegram posts to the production channel
- document the difference between CI and production chat IDs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686ea4b4687c83329e7c0c81ef118450