### PR TITLE
fix: include timezone in API dates

### DIFF
--- a/src/hh.rs
+++ b/src/hh.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, Utc};
+use chrono::{Duration, SecondsFormat, Utc};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -43,8 +43,11 @@ impl HhClient {
                 ("search_field", "name"),
                 ("per_page", "100"),
                 ("order_by", "publication_time"),
-                ("date_from", &from.format("%Y-%m-%dT%H:%M:%S").to_string()),
-                ("date_to", &to.format("%Y-%m-%dT%H:%M:%S").to_string()),
+                (
+                    "date_from",
+                    &from.to_rfc3339_opts(SecondsFormat::Secs, true),
+                ),
+                ("date_to", &to.to_rfc3339_opts(SecondsFormat::Secs, true)),
             ])
             .header(
                 "User-Agent",


### PR DESCRIPTION
## Summary
- use `to_rfc3339_opts` to include the timezone in `date_from` and `date_to` arguments

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_687138c3927483328e342efec8e25ae2