### PR TITLE
Update release workflow token usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,5 +33,5 @@ jobs:
           tag_name: latest
           files: target/release/rust-hh-feed
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 


### PR DESCRIPTION
## Summary
- add `permissions` section for write access in release workflow
- switch the release token to `GH_PAT`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68719f03ce788332b10921d68886ea0f