### PR TITLE
Add backlog task for fixing release workflow

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -27,12 +27,17 @@ jobs:
             target
           key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build and run
+      - name: Download release binary
+        run: |
+          curl -sSL -o rust-hh-feed \
+            https://github.com/${{ github.repository }}/releases/latest/download/rust-hh-feed
+          chmod +x rust-hh-feed
+
+      - name: Run
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           CARGO_TERM_PROGRESS_WHEN: never
           MANUAL_MODE: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          cargo run --release --quiet
+        run: ./rust-hh-feed
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,10 @@
+# Backlog
+
+This document lists open tasks and upcoming improvements for the project.
+
+
+## Tasks
+
+- [ ] Restore uploading the release binary in `.github/workflows/release.yml`.
+- [x] Update `.github/workflows/post.yml` to download the binary from the `latest` release instead of rebuilding on each run.
+


### PR DESCRIPTION
## Summary
- document backlog tasks for fixing release binary upload and post workflow
- update post workflow to use release binary

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6871a1516f688332b37cbf4508633d90