### PR TITLE
Update state storage to use artifacts

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -27,6 +27,16 @@ jobs:
             target
           key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Download posted jobs state
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: post.yml
+          name: posted_jobs
+          path: data
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_conclusion: success
+          if_no_artifact_found: warn
+
       - name: Download release binary
         run: |
           curl -sSL -o rust-hh-feed \
@@ -40,6 +50,12 @@ jobs:
           CARGO_TERM_PROGRESS_WHEN: never
           MANUAL_MODE: ${{ github.event_name == 'workflow_dispatch' }}
         run: ./rust-hh-feed
+
+      - name: Upload posted jobs state
+        uses: actions/upload-artifact@v4
+        with:
+          name: posted_jobs
+          path: data/posted_jobs.json
 
       - name: Notify failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The bot expects a few environment variables:
 | `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
 | `RUN_INTEGRATION` | Set to `true` to run the bot during CI |
 
+The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous workflow run and uploaded back as an artifact after each execution.
+
 During continuous integration the bot posts to the development channel
 configured by `DEV_TELEGRAM_CHAT_ID`. Scheduled runs and manual releases use
 `TELEGRAM_CHAT_ID` to post to the production channel.

--- a/docs/TECHNICAL_DETAILS.md
+++ b/docs/TECHNICAL_DETAILS.md
@@ -1,6 +1,6 @@
 # Publication State Storage Architecture
 
-This document describes how the bot stores information about vacancies that have already been sent to the Telegram channel. The data is kept in the `data/posted_jobs.json` file.
+This document describes how the bot stores information about vacancies that have already been sent to the Telegram channel. The data is saved in the `posted_jobs.json` file, which is persisted between runs as a pipeline artifact rather than in the repository.
 
 ## `posted_jobs.json` Format
 
@@ -15,11 +15,12 @@ The file is a dictionary where each key is a HeadHunter vacancy ID and the value
 
 ## Typical Workflow
 
-1. On startup the bot loads `posted_jobs.json` into memory (for example, as `HashMap<String, String>`).
-2. For each vacancy found:
+1. The CI workflow downloads `posted_jobs.json` from the previous successful run and places it in the `data` directory.
+2. On startup the bot loads the file into memory (for example, as `HashMap<String, String>`).
+3. For each vacancy found:
    - if the ID already exists in the file, the vacancy is skipped;
    - otherwise the bot publishes it and adds a record to the JSON.
-3. After posting, the file is updated and committed back to the repository automatically.
+4. After posting, the file is updated and uploaded as an artifact so that the next pipeline run can download it.
 
 ## Why JSON
 


### PR DESCRIPTION
## Summary
- store `posted_jobs.json` as a workflow artifact
- document the artifact-based workflow
- explain the artifact in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687a13b952148332b831c842510514ee