### PR TITLE
Implement job retention cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 POSTED_JOBS_PATH=data/posted_jobs.json
 MANUAL_MODE=false
 RUN_INTEGRATION=false
+JOB_RETENTION_DAYS=30

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The bot expects a few environment variables:
 | `POSTED_JOBS_PATH` | Path to the JSON file with already posted jobs |
 | `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
 | `RUN_INTEGRATION` | Set to `true` to run the bot during CI |
+| `JOB_RETENTION_DAYS` | Maximum age in days to keep posted job IDs |
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous workflow run and uploaded back as an artifact after each execution.
 

--- a/docs/TECHNICAL_DETAILS.md
+++ b/docs/TECHNICAL_DETAILS.md
@@ -20,7 +20,8 @@ The file is a dictionary where each key is a HeadHunter vacancy ID and the value
 3. For each vacancy found:
    - if the ID already exists in the file, the vacancy is skipped;
    - otherwise the bot publishes it and adds a record to the JSON.
-4. After posting, the file is updated and uploaded as an artifact so that the next pipeline run can download it.
+4. After posting, the bot removes entries older than `JOB_RETENTION_DAYS` (30 by default).
+5. The file is then updated and uploaded as an artifact so that the next pipeline run can download it.
 
 ## Why JSON
 

--- a/tests/main_skip_duplicates.rs
+++ b/tests/main_skip_duplicates.rs
@@ -27,6 +27,7 @@ fn main_skips_already_posted() {
         .env("TELEGRAM_API_BASE_URL", server_url())
         .env("TELEGRAM_BOT_TOKEN", "token")
         .env("TELEGRAM_CHAT_ID", "1")
+        .env("JOB_RETENTION_DAYS", "1000")
         .env("POSTED_JOBS_PATH", &state_path)
         .assert()
         .success();


### PR DESCRIPTION
## Summary
- add `prune_old_jobs` to purge outdated entries
- respect `JOB_RETENTION_DAYS` in main
- document new setting in README and docs
- update `.env.example`
- adjust tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687e09f51b0083328c5823da1c526f97