### PR TITLE
Add workflow cleanup job

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -67,3 +67,34 @@ jobs:
             -d chat_id="${CHAT_ID}" \
             -d text="❌ Workflow '${{ github.workflow }}' failed. See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+  cleanup-old-runs:
+    needs: run-bot
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete old workflow runs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'post.yml',
+                status: 'completed'
+              }
+            );
+            for (const run of runs) {
+              if (Date.parse(run.updated_at) < cutoff) {
+                await github.rest.actions.deleteWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+              }
+            }
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
    - Runs the update process once per hour, typically via GitHub Actions.
+   - Removes workflow runs older than two weeks using the `cleanup-old-runs` job.
 
 ## Data Flow
 1. The scheduler initiates the task.


### PR DESCRIPTION
## Summary
- cleanup old workflow runs after posting to Telegram
- describe job cleanup in docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_687e0ef77dac8332bd0069032cf5c66e