### PR TITLE
Update cleanup retention

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+            const cutoff = Date.now() - 3 * 24 * 60 * 60 * 1000;
             const runs = await github.paginate(
               github.rest.actions.listWorkflowRuns,
               {


### PR DESCRIPTION
## Summary
- change old-run cleanup retention to 3 days

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687e2b0221cc83329f79d205af3b08df