### PR TITLE
Fix cleanup job token

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Delete old workflow runs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const cutoff = Date.now() - 3 * 24 * 60 * 60 * 1000;
             const runs = await github.paginate(

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Additional workflows automate repository maintenance:
 
 - `pr_cleanup.yml` cancels running CI jobs and deletes the branch after a pull request is merged while skipping its own run.
 - `manual_release.yml` allows manual execution of the bot through the GitHub UI.
- 
+- The `cleanup-old-runs` job inside `post.yml` uses the `GH_PAT` secret to remove workflow runs older than three days. The token requires the `repo` and `actions: write` scopes.
+
 
 ## Release Binary
 A push to the `main` branch updates the `latest` release with a freshly built executable. Only one file, `rust-hh-feed`, is kept in the release. Download it with:


### PR DESCRIPTION
## Summary
- switch to the `GH_PAT` secret for deleting workflow runs
- document PAT requirement in README

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687e34dc2d008332bf82713889831c5d