### PR TITLE
Fix missing github token

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -22,6 +22,7 @@ jobs:
         id: pr
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             core.setOutput('number', pr ? pr.number : '');

--- a/.github/workflows/pr_cleanup.yml
+++ b/.github/workflows/pr_cleanup.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Cancel running workflows for PR
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const branch = '${{ github.event.pull_request.head.ref }}';
             const currentRunId = Number(process.env.GITHUB_RUN_ID);


### PR DESCRIPTION
## Summary
- pass `github-token` to `actions/github-script` in cleanup and auto merge workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687f529235088332a130f21af1ebc27c