### PR TITLE
Fix cleanup job token

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Delete old workflow runs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const cutoff = Date.now() - 3 * 24 * 60 * 60 * 1000;
             const runs = await github.paginate(


### PR DESCRIPTION
## Summary
- use `GITHUB_TOKEN` for deleting old workflow runs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687f6db5237483328278efeac247e2e9