### PR TITLE
Extend workflow cleanup

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -79,22 +79,31 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const cutoff = Date.now() - 3 * 24 * 60 * 60 * 1000;
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
+            const workflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
               {
                 owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'post.yml',
-                status: 'completed'
+                repo: context.repo.repo
               }
             );
-            for (const run of runs) {
-              if (Date.parse(run.updated_at) < cutoff) {
-                await github.rest.actions.deleteWorkflowRun({
+            for (const wf of workflows) {
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  run_id: run.id
-                });
+                  workflow_id: wf.id,
+                  status: 'completed'
+                }
+              );
+              for (const run of runs) {
+                if (Date.parse(run.updated_at) < cutoff) {
+                  await github.rest.actions.deleteWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id
+                  });
+                }
               }
             }
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Additional workflows automate repository maintenance:
 
 - `pr_cleanup.yml` cancels running CI jobs and deletes the branch after a pull request is merged while skipping its own run.
 - `manual_release.yml` allows manual execution of the bot through the GitHub UI.
-- The `cleanup-old-runs` job inside `post.yml` uses the `GH_PAT` secret to remove workflow runs older than three days. The token requires the `repo` and `actions: write` scopes.
+ - The `cleanup-old-runs` job inside `post.yml` deletes completed runs of all workflows after three days using `GITHUB_TOKEN` with the `actions: write` permission.
 
 
 ## Release Binary

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
    - Runs the update process once per hour, typically via GitHub Actions.
-   - Removes workflow runs older than two weeks using the `cleanup-old-runs` job.
+   - Removes completed workflow runs older than three days using the `cleanup-old-runs` job.
 
 ## Data Flow
 1. The scheduler initiates the task.


### PR DESCRIPTION
## Summary
- delete runs from all workflows in `post.yml`
- clarify the cleanup token in README
- note 3-day cleanup in docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687f9b8323fc8332b2d7bf0acb3b035d