### PR TITLE
Fix artifact download handling

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   run-bot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,7 +38,7 @@ jobs:
           path: data
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow_conclusion: success
-          if_no_artifact_found: warn
+          if_no_artifact_found: fail
 
       - name: Download release binary
         run: |


### PR DESCRIPTION
## Summary
- fail `post.yml` workflow if `posted_jobs` artifact is missing
- add required `actions` permission so the artifact can be downloaded

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_688784f5814c833298803a3f1731aaf7