### PR TITLE
Enable info logs in scheduled runs

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -32,4 +32,5 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           CARGO_TERM_PROGRESS_WHEN: never
+          RUST_LOG: info
         run: ./rust-hh-feed

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -52,6 +52,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           CARGO_TERM_PROGRESS_WHEN: never
           MANUAL_MODE: ${{ github.event_name == 'workflow_dispatch' }}
+          RUST_LOG: info
         run: ./rust-hh-feed
 
       - name: Upload posted jobs state


### PR DESCRIPTION
## Summary
- add `RUST_LOG=info` to `post.yml` and `manual_release.yml` workflows so info-level logs appear during scheduled and manual runs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_688c9ff586f88332af322dd9723ddf11