### PR TITLE
Extend fetch window to 90 minutes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
    - Runs the update process once per hour, typically via GitHub Actions.
+   - Requests vacancies published in the last 90 minutes to avoid gaps when the pipeline is slow.
    - Removes completed workflow runs older than three days using the `cleanup-old-runs` job.
 
 ## Data Flow

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -32,8 +32,8 @@ impl HhClient {
     pub async fn fetch_jobs(&self) -> Result<Vec<Job>, reqwest::Error> {
         let url = format!("{}/vacancies", self.base_url);
         let to = Utc::now();
-        // Narrow the search window to a single hour because the bot runs every hour.
-        let from = to - Duration::hours(1);
+        // Search the last 90 minutes to avoid missing jobs when the pipeline is slow.
+        let from = to - Duration::minutes(90);
         log::debug!("Requesting jobs from {url}");
         let resp = self
             .client


### PR DESCRIPTION
## Summary
- extend the requested time window from 60 minutes to 90 to avoid missing jobs
- document the new fetch interval in the architecture guide

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_688ca755f30c8332a3cfb8b6fc5e27cf