### PR TITLE
Search vacancies by title or description

### DIFF
--- a/src/hh.rs
+++ b/src/hh.rs
@@ -2,11 +2,18 @@ use chrono::{Duration, SecondsFormat, Utc};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+pub struct Snippet {
+    pub requirement: Option<String>,
+    pub responsibility: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Job {
     pub id: String,
     pub name: String,
     #[serde(rename = "alternate_url")]
     pub url: String,
+    pub snippet: Option<Snippet>,
 }
 
 pub struct HhClient {
@@ -40,7 +47,6 @@ impl HhClient {
             .get(&url)
             .query(&[
                 ("text", "Rust"),
-                ("search_field", "name"),
                 ("per_page", "100"),
                 ("order_by", "publication_time"),
                 (

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,18 @@ async fn main() -> anyhow::Result<()> {
 
     let new_jobs: Vec<_> = jobs
         .into_iter()
+        .filter(|job| {
+            let title_has_rust = job.name.to_lowercase().contains("rust");
+            let snippet_has_rust = job.snippet.as_ref().is_some_and(|s| {
+                s.requirement
+                    .as_deref()
+                    .is_some_and(|r| r.to_lowercase().contains("rust"))
+                    || s.responsibility
+                        .as_deref()
+                        .is_some_and(|r| r.to_lowercase().contains("rust"))
+            });
+            title_has_rust || snippet_has_rust
+        })
         .filter(|job| !posted.contains_key(&job.id))
         .collect();
     log::info!("Found {} new job(s)", new_jobs.len());

--- a/tests/hh_client.rs
+++ b/tests/hh_client.rs
@@ -3,7 +3,7 @@ use rust_hh_feed::hh::HhClient;
 
 #[tokio::test]
 async fn fetch_jobs_parses_mock_response() {
-    let body = r#"{"items":[{"id":"1","name":"Rust dev","alternate_url":"http://example.com/1"}]}"#;
+    let body = r#"{"items":[{"id":"1","name":"Rust dev","alternate_url":"http://example.com/1","snippet":{"requirement":"Rust experience"}}]}"#;
     let _m = mock("GET", "/vacancies")
         .match_query(Matcher::Any)
         .with_status(200)
@@ -19,4 +19,8 @@ async fn fetch_jobs_parses_mock_response() {
     assert_eq!(job.id, "1");
     assert_eq!(job.name, "Rust dev");
     assert_eq!(job.url, "http://example.com/1");
+    assert_eq!(
+        job.snippet.as_ref().and_then(|s| s.requirement.as_deref()),
+        Some("Rust experience"),
+    );
 }

--- a/tests/main_description.rs
+++ b/tests/main_description.rs
@@ -1,0 +1,39 @@
+use assert_cmd::Command;
+use mockito::{mock, server_url};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn main_posts_jobs_with_rust_in_description() {
+    let hh_body = r#"{"items":[{"id":"1","name":"Backend dev","alternate_url":"http://example.com/1","snippet":{"requirement":"Proficiency in Rust"}}]}"#;
+    let _hh_mock = mock("GET", "/vacancies")
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(hh_body)
+        .create();
+
+    let _tg_mock = mock("POST", "/bottoken/sendMessage")
+        .expect(1)
+        .with_status(200)
+        .create();
+
+    let dir = tempdir().unwrap();
+    let state_path = dir.path().join("state.json");
+
+    Command::cargo_bin("rust-hh-feed")
+        .unwrap()
+        .env("HH_BASE_URL", server_url())
+        .env("TELEGRAM_API_BASE_URL", server_url())
+        .env("TELEGRAM_BOT_TOKEN", "token")
+        .env("TELEGRAM_CHAT_ID", "1")
+        .env("POSTED_JOBS_PATH", &state_path)
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&state_path).unwrap();
+    assert!(content.contains("\"1\""));
+
+    _hh_mock.assert();
+    _tg_mock.assert();
+}


### PR DESCRIPTION
## Summary
- Broaden hh.ru query to search description text as well as titles
- Capture vacancy snippet fields for later filtering
- Filter out jobs without "Rust" in title or description snippet and test description-based matching

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_689427e643388332a16625fb71725d4f