### PR TITLE
Ignore Rust mentions in job descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 ## Main Features
 
 - Query the hh.ru API for fresh vacancies using the keyword "Rust".
-- Filter vacancies where "Rust" appears in the title or key requirements.
+- Filter vacancies where "Rust" appears in the title.
 - Publish the results to a Telegram channel via a bot.
 - Schedule the process to run every hour.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This document describes the intended structure of the bot that searches for vaca
 
 1. **hh_feed module**
    - Queries the hh.ru API with the search term `Rust`.
-   - Selects vacancies where "Rust" appears in the title or main requirements.
+   - Selects vacancies where "Rust" appears in the title.
    - Extracts contact details and a job link when possible.
 2. **Telegram module**
    - Uses the Bot API to send messages.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,18 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let new_jobs: Vec<_> = jobs
         .into_iter()
-        .filter(|job| {
-            let title_has_rust = job.name.to_lowercase().contains("rust");
-            let snippet_has_rust = job.snippet.as_ref().is_some_and(|s| {
-                s.requirement
-                    .as_deref()
-                    .is_some_and(|r| r.to_lowercase().contains("rust"))
-                    || s.responsibility
-                        .as_deref()
-                        .is_some_and(|r| r.to_lowercase().contains("rust"))
-            });
-            title_has_rust || snippet_has_rust
-        })
+        .filter(|job| job.name.to_lowercase().contains("rust"))
         .filter(|job| !posted.contains_key(&job.id))
         .collect();
     log::info!("Found {} new job(s)", new_jobs.len());

--- a/tests/main_description.rs
+++ b/tests/main_description.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
-fn main_posts_jobs_with_rust_in_description() {
+fn main_ignores_jobs_with_rust_only_in_description() {
     let hh_body = r#"{"items":[{"id":"1","name":"Backend dev","alternate_url":"http://example.com/1","snippet":{"requirement":"Proficiency in Rust"}}]}"#;
     let _hh_mock = mock("GET", "/vacancies")
         .match_query(mockito::Matcher::Any)
@@ -14,7 +14,7 @@ fn main_posts_jobs_with_rust_in_description() {
         .create();
 
     let _tg_mock = mock("POST", "/bottoken/sendMessage")
-        .expect(1)
+        .expect(0)
         .with_status(200)
         .create();
 
@@ -32,7 +32,7 @@ fn main_posts_jobs_with_rust_in_description() {
         .success();
 
     let content = fs::read_to_string(&state_path).unwrap();
-    assert!(content.contains("\"1\""));
+    assert!(!content.contains("\"1\""));
 
     _hh_mock.assert();
     _tg_mock.assert();


### PR DESCRIPTION
## Summary
- check job titles only for Rust keyword
- adjust integration test for description filtering
- document filtering by title only

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6894a26c1edc8332afd944c4d8029973