### PR TITLE
docs: update configuration variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_CHAT_ID=your_channel_id_here
-DEV_TELEGRAM_CHAT_ID=your_dev_channel_id_here
 HH_BASE_URL=https://api.hh.ru
 TELEGRAM_API_BASE_URL=https://api.telegram.org
 POSTED_JOBS_PATH=data/posted_jobs.json
 MANUAL_MODE=false
-RUN_INTEGRATION=false
 JOB_RETENTION_DAYS=30

--- a/README.md
+++ b/README.md
@@ -28,19 +28,16 @@ The bot expects a few environment variables:
 |----------|--------------------------------------------------------------|
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token |
 | `TELEGRAM_CHAT_ID` | ID of the channel to post jobs |
-| `DEV_TELEGRAM_CHAT_ID` | ID of the development channel used in CI |
 | `HH_BASE_URL` | Override base URL for the HeadHunter API |
 | `TELEGRAM_API_BASE_URL` | Override base URL for the Telegram Bot API |
 | `POSTED_JOBS_PATH` | Path to the JSON file with already posted jobs |
 | `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
-| `RUN_INTEGRATION` | Set to `true` to run the bot during CI |
 | `JOB_RETENTION_DAYS` | Maximum age in days to keep posted job IDs |
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous workflow run and uploaded back as an artifact after each execution.
 
-During continuous integration the bot posts to the development channel
-configured by `DEV_TELEGRAM_CHAT_ID`. Scheduled runs and manual releases use
-`TELEGRAM_CHAT_ID` to post to the production channel.
+During continuous integration the workflow sets `TELEGRAM_CHAT_ID` to a development channel.
+Scheduled runs and manual releases use the production chat ID.
 
 Set the `RUST_LOG` environment variable to control the logging level, for
 example `RUST_LOG=info`.


### PR DESCRIPTION
## Summary
- drop unused DEV_TELEGRAM_CHAT_ID and RUN_INTEGRATION variables
- clarify how TELEGRAM_CHAT_ID is used for dev channel
- sync `.env.example` with updated configuration list

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_689c4bc642688332bb32e52b08317b8f