### PR TITLE
feat: broaden search keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 
 ## Main Features
 
-- Query the hh.ru API for fresh vacancies using the keyword "Rust".
+- Query the hh.ru API for fresh vacancies using keywords such as `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
 - Filter vacancies where "Rust" appears in the title.
 - Publish the results to a Telegram channel via a bot.
 - Schedule the process to run every hour.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This document describes the intended structure of the bot that searches for vaca
 ## Components
 
 1. **hh_feed module**
-   - Queries the hh.ru API with the search term `Rust`.
+   - Queries the hh.ru API with search terms like `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
    - Selects vacancies where "Rust" appears in the title.
    - Extracts contact details and a job link when possible.
 2. **Telegram module**

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -21,6 +21,16 @@ pub struct HhClient {
     base_url: String,
 }
 
+/// List of lower-case search terms used to query HeadHunter.
+/// Variations cover common spellings of Rust-related job titles.
+const SEARCH_TERMS: &[&str] = &[
+    "rust",
+    "rust-разработчик",
+    "rust-developer",
+    "rust-programmer",
+    "rust-программист",
+];
+
 impl HhClient {
     pub fn new() -> Self {
         Self {
@@ -42,11 +52,12 @@ impl HhClient {
         // Search the last 90 minutes to avoid missing jobs when the pipeline is slow.
         let from = to - Duration::minutes(90);
         log::debug!("Requesting jobs from {url}");
+        let search_query = SEARCH_TERMS.join(" OR ");
         let resp = self
             .client
             .get(&url)
             .query(&[
-                ("text", "Rust"),
+                ("text", search_query.as_str()),
                 ("per_page", "100"),
                 ("order_by", "publication_time"),
                 (


### PR DESCRIPTION
## Summary
- broaden job search with multiple lowercase Rust keywords
- document additional search terms

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_689f0ffecbf8833296e6003bf48d9ceb