### PR TITLE
Reduce job search window to 45 minutes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
    - Runs the update process once per hour, typically via GitHub Actions.
-   - Requests vacancies published in the last 90 minutes to avoid gaps when the pipeline is slow.
+   - Requests vacancies published in the last 45 minutes to avoid gaps when the pipeline is slow.
    - Removes completed workflow runs older than three days using the `cleanup-old-runs` job.
 
 ## Data Flow

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -49,8 +49,8 @@ impl HhClient {
     pub async fn fetch_jobs(&self) -> Result<Vec<Job>, reqwest::Error> {
         let url = format!("{}/vacancies", self.base_url);
         let to = Utc::now();
-        // Search the last 90 minutes to avoid missing jobs when the pipeline is slow.
-        let from = to - Duration::minutes(90);
+        // Search the last 45 minutes to avoid missing jobs when the pipeline is slow.
+        let from = to - Duration::minutes(45);
         log::debug!("Requesting jobs from {url}");
         let search_query = SEARCH_TERMS.join(" OR ");
         let resp = self


### PR DESCRIPTION
## Summary
- Narrow HeadHunter search window to 45 minutes to avoid missing jobs while reducing stale results
- Document scheduler interval change to 45 minutes

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68ac1833d270833285cb9de01097851c