### PR TITLE
Run post workflow twice per hour

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -2,7 +2,7 @@ name: Post to Telegram
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0,30 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- run post workflow twice per hour by adjusting cron schedule

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68ac1833249c83329fa9df4346c4f203