### PR TITLE
Recover HH posting and add backfill support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_CHAT_ID=your_channel_id_here
 HH_BASE_URL=https://api.hh.ru
+HH_USER_AGENT=YourAppName/1.0 (your@email.example)
+BACKFILL_HOURS=
 TELEGRAM_API_BASE_URL=https://api.telegram.org
 POSTED_JOBS_PATH=data/posted_jobs.json
 MANUAL_MODE=false

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -2,6 +2,11 @@ name: Manual Release
 
 on:
   workflow_dispatch:
+    inputs:
+      backfill_hours:
+        description: 'Optional: widen the fetch window for one-off backfills'
+        required: false
+        type: string
 
 jobs:
   run-bot:
@@ -36,6 +41,8 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          BACKFILL_HOURS: ${{ inputs.backfill_hours }}
+          HH_USER_AGENT: ${{ vars.HH_USER_AGENT }}
           RUST_LOG: info
           BINARY_NAME: rust-hh-feed
         run: |

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       backfill_hours:
-        description: 'Optional: widen the fetch window for one-off backfills'
+        description: 'Optional: widen the fetch window for one-off backfills, typically 72'
         required: false
         type: string
 

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0,30 * * * *'
   workflow_dispatch:
+    inputs:
+      backfill_hours:
+        description: 'Optional: widen the fetch window for one-off backfills'
+        required: false
+        type: string
 
 concurrency:
   group: post-to-telegram-${{ github.ref }}
@@ -48,6 +53,8 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          BACKFILL_HOURS: ${{ inputs.backfill_hours }}
+          HH_USER_AGENT: ${{ vars.HH_USER_AGENT }}
           MANUAL_MODE: ${{ github.event_name == 'workflow_dispatch' }}
           RUST_LOG: info
           BINARY_NAME: rust-hh-feed

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       backfill_hours:
-        description: 'Optional: widen the fetch window for one-off backfills'
+        description: 'Optional: widen the fetch window for one-off backfills, typically 72'
         required: false
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/actions/setup-rust/action.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ The bot expects a few environment variables:
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token |
 | `TELEGRAM_CHAT_ID` | ID of the channel to post jobs |
 | `HH_BASE_URL` | Override base URL for the HeadHunter API |
+| `HH_USER_AGENT` | Override the `User-Agent` header sent to the HeadHunter API |
+| `BACKFILL_HOURS` | Optional one-off override that widens the fetch window for backfills |
 | `TELEGRAM_API_BASE_URL` | Override base URL for the Telegram Bot API |
 | `POSTED_JOBS_PATH` | Path to the JSON file with already posted jobs |
 | `MANUAL_MODE` | Set to `true` to skip saving posted jobs |
 | `JOB_RETENTION_DAYS` | Maximum age in days to keep posted job IDs |
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous successful workflow run and uploaded back as an artifact only after a new successful execution. The state file also stores the timestamp of the last committed run so the bot can re-fetch vacancies after one or more failed runs.
+HeadHunter may reject requests with a blacklisted or invalid `User-Agent`, so production runs should define `HH_USER_AGENT` in GitHub Actions variables with a stable application identifier and contact.
+For one-off recovery runs you can set `BACKFILL_HOURS`, for example `120`, to fetch missed vacancies from the last five days in addition to the normal state-based window.
 
 During continuous integration the workflow sets `TELEGRAM_CHAT_ID` to a development channel.
 Scheduled runs and manual releases use the production chat ID.
@@ -75,7 +79,9 @@ grouped into a single weekly pull request to reduce merge churn, and
 third-party actions in the workflows are pinned to immutable commit SHAs. A
 push to `main` then triggers `release.yml`, which rebuilds the production
 binary and updates the [`latest`](../../releases/latest) release through the
-GitHub CLI used by the scheduled posting pipeline.
+GitHub CLI when the bot sources or build inputs change on `main`. The scheduled
+posting pipeline downloads that release asset instead of rebuilding the bot on
+every run.
 
 The CI job caches Cargo dependencies and build artifacts to speed up subsequent
 runs. For each update to the `main` branch the same workflow uploads the latest
@@ -85,8 +91,8 @@ download artifacts directly from the workflow run page.
 Additional workflows automate repository maintenance:
 
 - `pr_cleanup.yml` cancels running CI jobs and deletes the branch after a pull request is merged while skipping its own run.
-- `manual_release.yml` allows manual execution of the bot through the GitHub UI.
- - The `cleanup-old-runs` job inside `post.yml` deletes completed runs of all workflows after three days using `GITHUB_TOKEN` with the `actions: write` permission.
+- `manual_release.yml` allows manual execution of the bot through the GitHub UI using the current `latest` release asset.
+- The `cleanup-old-runs` job inside `post.yml` deletes completed runs of all workflows after three days using `GITHUB_TOKEN` with the `actions: write` permission.
 
 
 ## Release Binary

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The bot expects a few environment variables:
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous successful workflow run and uploaded back as an artifact only after a new successful execution. The state file also stores the timestamp of the last committed run so the bot can re-fetch vacancies after one or more failed runs.
 HeadHunter may reject requests with a blacklisted or invalid `User-Agent`, so production runs should define `HH_USER_AGENT` in GitHub Actions variables with a stable application identifier and contact.
-For one-off recovery runs you can set `BACKFILL_HOURS`, for example `120`, to fetch missed vacancies from the last five days in addition to the normal state-based window.
+For one-off recovery runs you can set `BACKFILL_HOURS`, typically `72`, to fetch missed vacancies from the last three days plus the normal overlap in addition to the state-based window.
 
 During continuous integration the workflow sets `TELEGRAM_CHAT_ID` to a development channel.
 Scheduled runs and manual releases use the production chat ID.

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -19,7 +19,6 @@ pub struct Job {
 
 #[derive(Debug, Deserialize)]
 struct VacanciesResponse {
-    #[serde(default)]
     items: Vec<Job>,
     pages: Option<u32>,
 }

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -27,6 +27,7 @@ struct VacanciesResponse {
 pub struct HhClient {
     client: reqwest::Client,
     base_url: String,
+    user_agent: String,
 }
 
 /// List of lower-case search terms used to query HeadHunter.
@@ -38,12 +39,24 @@ const SEARCH_TERMS: &[&str] = &[
     "rust-programmer",
     "rust-программист",
 ];
+const DEFAULT_USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; rust-bot/1.0; +https://github.com/qqrm/rust-hh-feed)";
+const USER_AGENT_ENV_VAR: &str = "HH_USER_AGENT";
+
+fn configured_user_agent() -> String {
+    std::env::var(USER_AGENT_ENV_VAR)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_USER_AGENT.to_owned())
+}
 
 impl HhClient {
     pub fn new() -> Self {
         Self {
             client: reqwest::Client::new(),
             base_url: "https://api.hh.ru".into(),
+            user_agent: configured_user_agent(),
         }
     }
 
@@ -51,6 +64,7 @@ impl HhClient {
         Self {
             client: reqwest::Client::new(),
             base_url: base_url.into(),
+            user_agent: configured_user_agent(),
         }
     }
 
@@ -88,12 +102,10 @@ impl HhClient {
             let response = self
                 .client
                 .get(request_url)
-                .header(
-                    "User-Agent",
-                    "Mozilla/5.0 (compatible; rust-bot/1.0; +https://github.com/qqrm/rust-hh-feed)",
-                )
+                .header("User-Agent", &self.user_agent)
                 .send()
                 .await?
+                .error_for_status()?
                 .json::<VacanciesResponse>()
                 .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rust_hh_feed::telegram;
 
 use anyhow::Context;
 use chrono::Utc;
-use state::{fetch_window_start, load_posted_jobs, prune_old_jobs, save_posted_jobs};
+use state::{load_posted_jobs, prune_old_jobs, resolve_fetch_window_start, save_posted_jobs};
 use std::path::Path;
 use telegram::TelegramBot;
 
@@ -12,6 +12,8 @@ use telegram::TelegramBot;
 const MANUAL_MODE_VAR: &str = "MANUAL_MODE";
 /// Environment variable that sets how many days to keep posted IDs.
 const JOB_RETENTION_VAR: &str = "JOB_RETENTION_DAYS";
+/// Environment variable that widens the fetch window for one-off backfills.
+const BACKFILL_HOURS_VAR: &str = "BACKFILL_HOURS";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -30,7 +32,30 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(30);
     prune_old_jobs(&mut state.jobs, retention_days);
     let now = Utc::now();
-    let fetch_from = fetch_window_start(state.last_successful_run_at, now);
+    let backfill_hours = std::env::var(BACKFILL_HOURS_VAR)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| {
+            value.parse::<i64>().with_context(|| {
+                format!("{BACKFILL_HOURS_VAR} must be a positive integer number of hours")
+            })
+        })
+        .transpose()?
+        .map(|hours| {
+            anyhow::ensure!(
+                hours > 0,
+                "{BACKFILL_HOURS_VAR} must be a positive integer number of hours"
+            );
+            Ok(hours)
+        })
+        .transpose()?;
+    let fetch_from = resolve_fetch_window_start(state.last_successful_run_at, now, backfill_hours);
+    if let Some(hours) = backfill_hours {
+        log::warn!(
+            "Backfill mode enabled, widening fetch window to the last {} hour(s)",
+            hours
+        );
+    }
     log::info!(
         "Fetching jobs between {} and {}",
         fetch_from.to_rfc3339(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs, path::Path};
 
 pub type PostedJobs = HashMap<String, String>;
+const FETCH_OVERLAP_MINUTES: i64 = 15;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PostedJobsState {
@@ -81,7 +82,7 @@ pub fn fetch_window_start(
     last_successful_run_at: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
 ) -> DateTime<Utc> {
-    let overlap = Duration::minutes(15);
+    let overlap = Duration::minutes(FETCH_OVERLAP_MINUTES);
     last_successful_run_at
         .map(|timestamp| timestamp - overlap)
         .unwrap_or_else(|| default_fetch_window_start(now))
@@ -95,7 +96,9 @@ pub fn resolve_fetch_window_start(
     let state_start = fetch_window_start(last_successful_run_at, now);
 
     match backfill_hours {
-        Some(hours) if hours > 0 => state_start.min(now - Duration::hours(hours)),
+        Some(hours) if hours > 0 => {
+            state_start.min(now - Duration::hours(hours) - Duration::minutes(FETCH_OVERLAP_MINUTES))
+        }
         _ => state_start,
     }
 }
@@ -207,7 +210,7 @@ mod tests {
 
         let start = resolve_fetch_window_start(Some(last_success), now, Some(48));
 
-        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 1, 8, 0, 0).unwrap());
+        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 1, 7, 45, 0).unwrap());
     }
 
     #[test]
@@ -217,6 +220,6 @@ mod tests {
 
         let start = resolve_fetch_window_start(Some(last_success), now, Some(1));
 
-        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 3, 7, 0, 0).unwrap());
+        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 3, 6, 45, 0).unwrap());
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -87,6 +87,19 @@ pub fn fetch_window_start(
         .unwrap_or_else(|| default_fetch_window_start(now))
 }
 
+pub fn resolve_fetch_window_start(
+    last_successful_run_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    backfill_hours: Option<i64>,
+) -> DateTime<Utc> {
+    let state_start = fetch_window_start(last_successful_run_at, now);
+
+    match backfill_hours {
+        Some(hours) if hours > 0 => state_start.min(now - Duration::hours(hours)),
+        _ => state_start,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,5 +198,25 @@ mod tests {
         let start = fetch_window_start(None, now);
 
         assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 3, 7, 15, 0).unwrap());
+    }
+
+    #[test]
+    fn resolve_fetch_window_start_uses_earlier_backfill_window() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 3, 8, 0, 0).unwrap();
+        let last_success = Utc.with_ymd_and_hms(2026, 4, 3, 7, 30, 0).unwrap();
+
+        let start = resolve_fetch_window_start(Some(last_success), now, Some(48));
+
+        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 1, 8, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn resolve_fetch_window_start_uses_backfill_window_even_when_it_only_expands_slightly() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 3, 8, 0, 0).unwrap();
+        let last_success = Utc.with_ymd_and_hms(2026, 4, 3, 7, 30, 0).unwrap();
+
+        let start = resolve_fetch_window_start(Some(last_success), now, Some(1));
+
+        assert_eq!(start, Utc.with_ymd_and_hms(2026, 4, 3, 7, 0, 0).unwrap());
     }
 }

--- a/tests/hh_client.rs
+++ b/tests/hh_client.rs
@@ -1,5 +1,6 @@
 use chrono::{SecondsFormat, TimeZone, Utc};
 use mockito::{Matcher, Server};
+use reqwest::StatusCode;
 use rust_hh_feed::hh::HhClient;
 
 #[tokio::test]
@@ -90,4 +91,24 @@ async fn fetch_jobs_between_requests_all_pages_for_range() {
 
     first_page.assert_async().await;
     second_page.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_jobs_fails_on_unsuccessful_status() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/vacancies")
+        .match_query(Matcher::Any)
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"errors":[{"type":"forbidden"}]}"#)
+        .create_async()
+        .await;
+
+    let client = HhClient::with_base_url(server.url());
+    let error = client.fetch_jobs().await.unwrap_err();
+
+    assert_eq!(error.status(), Some(StatusCode::FORBIDDEN));
+
+    mock.assert_async().await;
 }

--- a/tests/hh_client.rs
+++ b/tests/hh_client.rs
@@ -112,3 +112,23 @@ async fn fetch_jobs_fails_on_unsuccessful_status() {
 
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn fetch_jobs_fails_on_invalid_success_payload() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/vacancies")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"description":"unexpected payload"}"#)
+        .create_async()
+        .await;
+
+    let client = HhClient::with_base_url(server.url());
+    let error = client.fetch_jobs().await.unwrap_err();
+
+    assert!(error.is_decode());
+
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
Fix silent HH API failures, make the HH User-Agent configurable, and add a one-off backfill window for missed vacancies.

## Problem
The posting pipeline was succeeding while HeadHunter API requests were failing. Non-2xx HH responses were effectively treated as empty vacancy lists, so the bot logged `Found 0 new job(s)` instead of failing. We also confirmed HH was rejecting requests with `Bad User-Agent header`, which explains the missing posts after April 14, 2026.

## Solution
- fail fast on non-success HH responses
- read `HH_USER_AGENT` from environment and wire it into Actions workflows
- rebuild `latest` automatically when bot code or build inputs change on `main`
- add `BACKFILL_HOURS` so a manual run can recover missed vacancies without permanently widening the normal window
- document the new operational knobs

## Scope
Included:
- HH client error handling
- configurable HH User-Agent
- release trigger narrowing
- manual/scheduled workflow inputs for backfill
- docs and regression tests

Not included:
- an automatic backfill after merge
- any change to vacancy filtering semantics beyond surfacing HH failures correctly

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

## Risks
The configured `HH_USER_AGENT` may still need adjustment if HH rejects this identifier too. After merge, the new `latest` binary must be published before a manual backfill run with `backfill_hours=120` can recover the missed five-day window.