### PR TITLE
Reduce scheduled posting frequency

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -2,7 +2,7 @@ name: Post to Telegram
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       backfill_hours:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-hh-feed
 
-This project collects job postings related to the Rust programming language from HeadHunter every 10 minutes and posts them to a Telegram channel.
+This project collects job postings related to the Rust programming language from HeadHunter every 20 minutes and posts them to a Telegram channel.
 You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 
 ## Main Features
@@ -8,7 +8,7 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 - Query the hh.ru API for fresh vacancies using keywords such as `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
 - Filter vacancies where "Rust" appears in the title.
 - Publish the results to a Telegram channel via a bot.
-- Schedule the process to run every 10 minutes.
+- Schedule the process to run every 20 minutes.
 
 ## Components
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ This document describes the intended structure of the bot that searches for vaca
    - Uses the Bot API to send messages.
    - Stores the token and channel ID in the configuration.
 3. **Scheduler**
-   - Runs the update process every 10 minutes, typically via GitHub Actions.
+   - Runs the update process every 20 minutes, typically via GitHub Actions.
    - Requests vacancies starting from the timestamp of the last successful run, with a small overlap window to avoid gaps near schedule boundaries.
    - Removes completed workflow runs older than three days using the `cleanup-old-runs` job.
 


### PR DESCRIPTION
## Summary
Reduce the scheduled posting workflow cadence from every 10 minutes to every 20 minutes and update the documentation to match.

## Problem
The posting workflow was hitting HeadHunter from GitHub Actions every 10 minutes. Given the recent access failures and likely anti-bot sensitivity, that cadence is unnecessarily aggressive.

## Solution
Change the cron schedule in post.yml to every 20 minutes and update the README and architecture documentation so the described cadence matches production.

## Scope
Included: scheduled workflow cadence and docs.
Excluded: any change to manual runs, backfill behavior, or HeadHunter request logic.

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

## Risks
This reduces request pressure, but it does not by itself solve GitHub runner access being blocked by HeadHunter.