### PR TITLE
Retry HH fetch across proxy routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The bot expects a few environment variables:
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous successful workflow run and uploaded back as an artifact only after a new successful execution. The state file also stores the timestamp of the last committed run so the bot can re-fetch vacancies after one or more failed runs.
 HeadHunter documents `User-Agent` and `HH-User-Agent` as interchangeable request headers, so the bot now sends both with the same value. Production runs should define `HH_USER_AGENT` in GitHub Actions variables using the documented application/contact format, for example `MyApp/1.0 (my-app-feedback@example.com)`.
-If `HH_PROXY_URLS` or `HH_PROXY_SOURCE_URLS` is configured, the bot probes candidates against the HeadHunter vacancies endpoint, selects the first proxy that actually works for vacancy search, and keeps Telegram traffic on the direct network path.
+If `HH_PROXY_URLS` or `HH_PROXY_SOURCE_URLS` is configured, the bot probes candidates against the HeadHunter vacancies endpoint, keeps the working proxies in order, and retries the real vacancies request through them until one succeeds before falling back to direct access. Telegram traffic always stays on the direct network path.
 For one-off recovery runs you can set `BACKFILL_HOURS`, typically `72`, to fetch missed vacancies from the last three days plus the normal overlap in addition to the state-based window.
 The bot always fetches from the last successful committed run with a small overlap window. If the state file is missing or does not contain a committed timestamp yet, it falls back to a wider bootstrap window to reduce the chance of missing vacancies during unstable scheduling.
 

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -28,9 +28,14 @@ struct VacanciesResponse {
 }
 
 pub struct HhClient {
-    client: Client,
+    routes: Vec<HhRoute>,
     base_url: String,
     user_agent: String,
+}
+
+struct HhRoute {
+    client: Client,
+    label: String,
 }
 
 /// List of lower-case search terms used to query HeadHunter.
@@ -235,7 +240,10 @@ async fn configured_proxy_candidates(timeout: Duration) -> Result<Vec<String>> {
 impl HhClient {
     pub fn new() -> Self {
         Self {
-            client: Client::new(),
+            routes: vec![HhRoute {
+                client: Client::new(),
+                label: "direct".to_owned(),
+            }],
             base_url: "https://api.hh.ru".into(),
             user_agent: configured_user_agent(),
         }
@@ -243,7 +251,10 @@ impl HhClient {
 
     pub fn with_base_url(base_url: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            routes: vec![HhRoute {
+                client: Client::new(),
+                label: "direct".to_owned(),
+            }],
             base_url: base_url.into(),
             user_agent: configured_user_agent(),
         }
@@ -258,10 +269,14 @@ impl HhClient {
         let user_agent = configured_user_agent();
         let timeout = configured_proxy_probe_timeout()?;
         let proxy_candidates = configured_proxy_candidates(timeout).await?;
+        let direct_client = build_client_with_timeout(timeout)?;
 
         if proxy_candidates.is_empty() {
             return Ok(Self {
-                client: build_client_with_timeout(timeout)?,
+                routes: vec![HhRoute {
+                    client: direct_client,
+                    label: "direct".to_owned(),
+                }],
                 base_url,
                 user_agent,
             });
@@ -272,6 +287,7 @@ impl HhClient {
             proxy_candidates.len()
         );
 
+        let mut routes = Vec::new();
         for candidate in proxy_candidates {
             let redacted = redact_proxy_url(&candidate);
             let client = match build_proxy_client(&candidate, timeout) {
@@ -283,23 +299,30 @@ impl HhClient {
             };
 
             if probe_vacancies_access(&client, &base_url, &user_agent).await {
-                log::info!("Using HeadHunter proxy {redacted}");
-                return Ok(Self {
+                log::info!("Accepted HeadHunter proxy candidate {redacted}");
+                routes.push(HhRoute {
                     client,
-                    base_url,
-                    user_agent,
+                    label: redacted,
                 });
+                continue;
             }
 
             log::warn!("Proxy {redacted} did not pass the HeadHunter vacancies probe");
         }
 
-        log::warn!(
-            "No configured proxy passed the HeadHunter vacancies probe, falling back to direct access"
-        );
+        if routes.is_empty() {
+            log::warn!(
+                "No configured proxy passed the HeadHunter vacancies probe, falling back to direct access"
+            );
+        }
+
+        routes.push(HhRoute {
+            client: direct_client,
+            label: "direct".to_owned(),
+        });
 
         Ok(Self {
-            client: build_client_with_timeout(timeout)?,
+            routes,
             base_url,
             user_agent,
         })
@@ -313,6 +336,33 @@ impl HhClient {
 
     pub async fn fetch_jobs_between(
         &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> Result<Vec<Job>, reqwest::Error> {
+        let mut last_error = None;
+
+        for route in &self.routes {
+            log::info!("Attempting HeadHunter fetch via {}", route.label);
+            match self.fetch_jobs_between_via(&route.client, from, to).await {
+                Ok(jobs) => {
+                    if route.label != "direct" {
+                        log::info!("HeadHunter fetch succeeded via {}", route.label);
+                    }
+                    return Ok(jobs);
+                }
+                Err(error) => {
+                    log::warn!("HeadHunter fetch failed via {}: {}", route.label, error);
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        Err(last_error.expect("HH client must have at least one route"))
+    }
+
+    async fn fetch_jobs_between_via(
+        &self,
+        client: &Client,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
     ) -> Result<Vec<Job>, reqwest::Error> {
@@ -337,8 +387,7 @@ impl HhClient {
                 )
                 .append_pair("date_to", &to.to_rfc3339_opts(SecondsFormat::Secs, true));
 
-            let response = self
-                .client
+            let response = client
                 .get(request_url)
                 .header(USER_AGENT, &self.user_agent)
                 .header(HH_USER_AGENT_HEADER.clone(), &self.user_agent)


### PR DESCRIPTION
## Summary
Retry the real HeadHunter vacancies fetch across the configured proxy routes in order until one succeeds, and only then stop. Keep direct access as the last fallback.

## Problem
The previous proxy failover work selected the first proxy that passed a lightweight vacancies probe at startup, but the actual fetch still used only that one route. If the later real query failed, the bot would not continue to the next viable proxy.

## Solution
Store the accepted HH routes in order, attempt the actual vacancies fetch through each route, stop on the first successful response, and use direct access last as a fallback. Update the README to describe the real retry behavior.

## Scope
Included: HH route retry order during the real vacancies request.
Excluded: any change to Telegram delivery or proxy source configuration.

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

## Risks
This improves failover behavior, but success still depends on at least one configured proxy actually being able to reach GET /vacancies.