### PR TITLE
Pause HeadHunter posting workflows

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   run-bot:
+    if: ${{ vars.HH_PIPELINES_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -1,8 +1,6 @@
 name: Post to Telegram
 
 on:
-  schedule:
-    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       backfill_hours:
@@ -16,6 +14,7 @@ concurrency:
 
 jobs:
   run-bot:
+    if: ${{ vars.HH_PIPELINES_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,6 +82,7 @@ jobs:
             -d text="❌ Workflow '${{ github.workflow }}' failed. See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   cleanup-old-runs:
+    if: ${{ vars.HH_PIPELINES_ENABLED == 'true' }}
     needs: run-bot
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-hh-feed
 
-This project collects job postings related to the Rust programming language from HeadHunter every 20 minutes and posts them to a Telegram channel.
+This project collects job postings related to the Rust programming language from HeadHunter and posts them to a Telegram channel.
 You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 
 ## Main Features
@@ -8,14 +8,14 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 - Query the hh.ru API for fresh vacancies using keywords such as `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
 - Filter vacancies where "Rust" appears in the title.
 - Publish the results to a Telegram channel via a bot.
-- Schedule the process to run every 20 minutes.
+- Run the posting pipeline from GitHub Actions when the HeadHunter workflows are enabled.
 
 ## Components
 
 1. **HeadHunter parser** — a Rust module that queries the API.
 2. **Collector and filter** — processes vacancies and selects relevant ones.
 3. **Telegram bot** — sends messages to the channel.
-4. **Scheduler** — triggers the collection and posting.
+4. **Scheduler** — triggers the collection and posting when the HeadHunter workflows are enabled.
 
 ## Documentation
 - [Project architecture](docs/README.md)
@@ -48,6 +48,7 @@ The bot always fetches from the last successful committed run with a small overl
 
 During continuous integration the workflow sets `TELEGRAM_CHAT_ID` to a development channel.
 Scheduled runs and manual releases use the production chat ID.
+The HeadHunter posting workflows are currently paused by default. To re-enable job posting after the HH access problem is resolved, restore the schedule in `post.yml` and set the GitHub Actions variable `HH_PIPELINES_ENABLED=true`.
 
 Set the `RUST_LOG` environment variable to control the logging level, for
 example `RUST_LOG=info`.
@@ -69,7 +70,7 @@ This keeps the logs short while still printing warnings and errors.
 ## Continuous Integration
 Pull requests trigger the [`ci.yml`](.github/workflows/ci.yml) workflow that checks formatting,
 lint rules, `cargo machete`, and tests. The `post.yml` workflow
-builds and runs the application either on schedule or manually. After
+can run the application manually when the HeadHunter workflows are enabled. After
 `ci.yml` succeeds, the `auto_merge.yml` workflow merges the pull request using the `gh` CLI.
 Dependabot now manages three update surfaces:
 
@@ -97,7 +98,7 @@ download artifacts directly from the workflow run page.
 Additional workflows automate repository maintenance:
 
 - `pr_cleanup.yml` cancels running CI jobs and deletes the branch after a pull request is merged while skipping its own run.
-- `manual_release.yml` allows manual execution of the bot through the GitHub UI using the current `latest` release asset.
+- `manual_release.yml` allows manual execution of the bot through the GitHub UI when `HH_PIPELINES_ENABLED=true`.
 - The `cleanup-old-runs` job inside `post.yml` deletes completed runs of all workflows after three days using `GITHUB_TOKEN` with the `actions: write` permission.
 
 


### PR DESCRIPTION
## Summary
Pause the HeadHunter posting workflows until the HH access problem is resolved.

## Problem
The project keeps probing proxies and sending failing HH requests, but HH still returns `403 Forbidden`. The user wants posting pipelines stopped until a proper access strategy is ready.

## Solution
Remove the scheduled trigger from `post.yml`, gate both posting workflows behind `HH_PIPELINES_ENABLED == true`, and update the README to document that HH posting is paused by default.

## Scope
Included: workflow trigger changes, workflow guards, and documentation.
Not included: any further HH integration changes or Telegram alert fixes.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

## Risks
Existing already-created workflow runs are unaffected. Re-enabling later will require both schedule restoration and explicit workflow re-enable/variable setup.
