### PR TITLE
Use HH search RSS for vacancy collection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_CHAT_ID=your_channel_id_here
-HH_BASE_URL=https://api.hh.ru
+HH_BASE_URL=https://hh.ru
 HH_USER_AGENT=YourAppName/1.0 (your@email.example)
 HH_PROXY_URLS=
 # Optional: override built-in public proxy providers with your own source URLs.

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -1,6 +1,8 @@
 name: Post to Telegram
 
 on:
+  schedule:
+    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       backfill_hours:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1256,7 @@ dependencies = [
  "env_logger",
  "log",
  "mockito",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 reqwest = { version = "0.13", features = ["json", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+quick-xml = { version = "0.38", features = ["serialize"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ You can join the Telegram channel at [RustHH Jobs](https://t.me/rusthhjobs).
 
 ## Main Features
 
-- Query the hh.ru API for fresh vacancies using keywords such as `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
+- Read the HeadHunter search RSS feed for fresh `rust` vacancies ordered by publication time.
 - Filter vacancies where "Rust" appears in the title.
 - Publish the results to a Telegram channel via a bot.
 - Run the posting pipeline from GitHub Actions when the HeadHunter workflows are enabled.
 
 ## Components
 
-1. **HeadHunter parser** — a Rust module that queries the API.
+1. **HeadHunter parser** — a Rust module that reads the HeadHunter search RSS feed.
 2. **Collector and filter** — processes vacancies and selects relevant ones.
 3. **Telegram bot** — sends messages to the channel.
 4. **Scheduler** — triggers the collection and posting when the HeadHunter workflows are enabled.
@@ -28,8 +28,8 @@ The bot expects a few environment variables:
 |----------|--------------------------------------------------------------|
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token |
 | `TELEGRAM_CHAT_ID` | ID of the channel to post jobs |
-| `HH_BASE_URL` | Override base URL for the HeadHunter API |
-| `HH_USER_AGENT` | Override the identification header value sent to the HeadHunter API |
+| `HH_BASE_URL` | Override base URL for the HeadHunter web host or a test double |
+| `HH_USER_AGENT` | Override the `User-Agent` value sent to HeadHunter search requests |
 | `HH_PROXY_URLS` | Optional comma- or newline-separated proxy URLs for HeadHunter requests only |
 | `HH_PROXY_SOURCE_URLS` | Optional comma- or newline-separated URLs that return proxy candidates; if unset, the bot polls built-in public proxy providers |
 | `HH_PROXY_PROBE_TIMEOUT_SECS` | Timeout for fetching and probing HeadHunter proxy candidates |
@@ -40,15 +40,15 @@ The bot expects a few environment variables:
 | `JOB_RETENTION_DAYS` | Maximum age in days to keep posted job IDs |
 
 The file referenced by `POSTED_JOBS_PATH` is not committed to the repository. It is downloaded from the previous successful workflow run and uploaded back as an artifact only after a new successful execution. The state file also stores the timestamp of the last committed run so the bot can re-fetch vacancies after one or more failed runs.
-HeadHunter documents `User-Agent` and `HH-User-Agent` as interchangeable request headers, so the bot now sends both with the same value. Production runs should define `HH_USER_AGENT` in GitHub Actions variables using the documented application/contact format, for example `MyApp/1.0 (my-app-feedback@example.com)`.
+The collector now uses the HeadHunter search RSS feed exposed by the public vacancy search page instead of the blocked `/vacancies` API endpoint. `HH_USER_AGENT` remains configurable so production runs can identify themselves consistently.
 The bot can dynamically poll several built-in public proxy providers for Russian free proxies when `HH_PROXY_SOURCE_URLS` is unset. If you do define `HH_PROXY_SOURCE_URLS`, those custom sources replace the built-in provider list.
-If `HH_PROXY_URLS` is configured or a proxy source returns candidates, the bot probes a bounded candidate set against the HeadHunter vacancies endpoint, keeps the working proxies in order, and retries the real vacancies request through them until one succeeds before falling back to direct access. Telegram traffic always stays on the direct network path.
+If `HH_PROXY_URLS` is configured or a proxy source returns candidates, the bot probes a bounded candidate set against the HeadHunter search RSS endpoint, keeps the working proxies in order, and retries the real feed request through them until one succeeds before falling back to direct access. Telegram traffic always stays on the direct network path.
 For one-off recovery runs you can set `BACKFILL_HOURS`, typically `72`, to fetch missed vacancies from the last three days plus the normal overlap in addition to the state-based window.
 The bot always fetches from the last successful committed run with a small overlap window. If the state file is missing or does not contain a committed timestamp yet, it falls back to a wider bootstrap window to reduce the chance of missing vacancies during unstable scheduling.
 
 During continuous integration the workflow sets `TELEGRAM_CHAT_ID` to a development channel.
 Scheduled runs and manual releases use the production chat ID.
-The HeadHunter posting workflows are currently paused by default. To re-enable job posting after the HH access problem is resolved, restore the schedule in `post.yml` and set the GitHub Actions variable `HH_PIPELINES_ENABLED=true`.
+The HeadHunter posting workflows run on a 20-minute schedule when the GitHub Actions variable `HH_PIPELINES_ENABLED=true`.
 
 Set the `RUST_LOG` environment variable to control the logging level, for
 example `RUST_LOG=info`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,10 +5,10 @@ This document describes the intended structure of the bot that searches for vaca
 ## Components
 
 1. **hh_feed module**
-   - Queries the hh.ru API with search terms like `rust`, `rust-разработчик`, `rust-developer`, `rust-programmer`, and `rust-программист`.
+   - Reads the HeadHunter vacancy search RSS feed with `text=rust`, `search_field=name`, and `order_by=publication_time`.
    - Selects vacancies where "Rust" appears in the title.
    - Extracts contact details and a job link when possible.
-   - Can poll built-in public proxy providers for Russian free proxies, probe them against `/vacancies`, and retry the real request through the first working routes before falling back to direct access.
+   - Can poll built-in public proxy providers for Russian free proxies, probe them against the RSS endpoint, and retry the real request through the first working routes before falling back to direct access.
 2. **Telegram module**
    - Uses the Bot API to send messages.
    - Stores the token and channel ID in the configuration.

--- a/docs/TECHNICAL_DETAILS.md
+++ b/docs/TECHNICAL_DETAILS.md
@@ -20,7 +20,7 @@ The file is a JSON object with metadata about the last committed run and a dicti
 ## Typical Workflow
 
 1. The CI workflow downloads `posted_jobs.json` from the previous successful run and places it in the `data` directory.
-2. On startup the bot loads the file into memory, reads `last_successful_run_at`, and requests vacancies from HeadHunter starting at that timestamp with a small overlap window.
+2. On startup the bot loads the file into memory, reads `last_successful_run_at`, and requests vacancies from the HeadHunter search RSS feed starting at that timestamp with a small overlap window.
 3. If the file is missing or does not contain a committed success timestamp yet, the bot falls back to a wider bootstrap window so that delayed or unstable workflow schedules do not cause immediate data loss.
 4. For each vacancy found:
    - if the ID already exists in the file, the vacancy is skipped;

--- a/src/hh.rs
+++ b/src/hh.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
-use chrono::{DateTime, SecondsFormat, Utc};
-use reqwest::header::{HeaderName, USER_AGENT};
+use chrono::{DateTime, Utc};
+use quick_xml::de::from_str;
+use reqwest::header::USER_AGENT;
 use reqwest::{Client, Proxy, Url};
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -23,9 +24,22 @@ pub struct Job {
 }
 
 #[derive(Debug, Deserialize)]
-struct VacanciesResponse {
-    items: Vec<Job>,
-    pages: Option<u32>,
+struct SearchRssFeed {
+    channel: SearchRssChannel,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchRssChannel {
+    #[serde(default)]
+    item: Vec<SearchRssItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchRssItem {
+    title: String,
+    link: String,
+    #[serde(rename = "pubDate")]
+    pub_date: String,
 }
 
 pub struct HhClient {
@@ -39,18 +53,9 @@ struct HhRoute {
     label: String,
 }
 
-/// List of lower-case search terms used to query HeadHunter.
-/// Variations cover common spellings of Rust-related job titles.
-const SEARCH_TERMS: &[&str] = &[
-    "rust",
-    "rust-разработчик",
-    "rust-developer",
-    "rust-programmer",
-    "rust-программист",
-];
+const SEARCH_QUERY: &str = "rust";
 const DEFAULT_USER_AGENT: &str = "rust-hh-feed/1.0 (qqrm@users.noreply.github.com)";
 const USER_AGENT_ENV_VAR: &str = "HH_USER_AGENT";
-const HH_USER_AGENT_HEADER: HeaderName = HeaderName::from_static("hh-user-agent");
 const PROXY_URLS_ENV_VAR: &str = "HH_PROXY_URLS";
 const PROXY_SOURCE_URLS_ENV_VAR: &str = "HH_PROXY_SOURCE_URLS";
 const PROXY_PROBE_TIMEOUT_SECS_ENV_VAR: &str = "HH_PROXY_PROBE_TIMEOUT_SECS";
@@ -405,41 +410,123 @@ fn build_proxy_client(proxy_url: &str, timeout: Duration) -> Result<Client> {
         .with_context(|| format!("failed to build HH client for proxy {proxy_url}"))
 }
 
-fn probe_request_url(base_url: &str) -> Url {
-    let url = format!("{base_url}/vacancies");
-    let mut request_url = Url::parse(&url).expect("HH vacancies URL must be valid");
-    request_url
-        .query_pairs_mut()
-        .append_pair("text", "rust")
-        .append_pair("per_page", "1")
-        .append_pair("page", "0")
-        .append_pair("order_by", "publication_time")
-        .append_pair("search_field", "name");
-    request_url
+fn web_base_url(base_url: &str) -> Result<Url> {
+    let mut url = Url::parse(base_url).context("HH base URL must be a valid absolute URL")?;
+
+    if let Some(host) = url.host_str().map(str::to_owned) {
+        if host == "api.hh.ru" {
+            url.set_host(Some("hh.ru"))
+                .expect("hh.ru must be a valid replacement host");
+        } else if host.starts_with("api.") && host.ends_with(".hh.ru") {
+            let replacement = host["api.".len()..].to_owned();
+            url.set_host(Some(&replacement))
+                .expect("HH host replacement must remain valid");
+        }
+    }
+
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
 }
 
-async fn probe_vacancies_access(client: &Client, base_url: &str, user_agent: &str) -> bool {
-    let request_url = probe_request_url(base_url);
+fn feed_request_url(base_url: &str) -> Result<Url> {
+    let base = web_base_url(base_url)?;
+    let mut request_url = base
+        .join("/search/vacancy/rss")
+        .context("failed to build HeadHunter RSS URL")?;
+    request_url
+        .query_pairs_mut()
+        .append_pair("order_by", "publication_time")
+        .append_pair("ored_clusters", "true")
+        .append_pair("search_field", "name")
+        .append_pair("text", SEARCH_QUERY);
+    Ok(request_url)
+}
+
+fn vacancy_id_from_link(link: &str) -> Option<String> {
+    let url = Url::parse(link).ok()?;
+    let segments: Vec<_> = url.path_segments()?.collect();
+    segments
+        .windows(2)
+        .find(|window| window[0] == "vacancy")
+        .map(|window| window[1].to_owned())
+}
+
+fn parse_rss_jobs(body: &str, from: DateTime<Utc>, to: DateTime<Utc>) -> Result<Vec<Job>> {
+    let feed: SearchRssFeed = from_str(body).context("failed to parse HeadHunter search RSS")?;
+
+    let mut jobs = Vec::new();
+    for item in feed.channel.item {
+        let published_at = DateTime::parse_from_rfc3339(&item.pub_date)
+            .with_context(|| {
+                format!(
+                    "failed to parse RSS publication timestamp {}",
+                    item.pub_date
+                )
+            })?
+            .with_timezone(&Utc);
+        if published_at < from || published_at > to {
+            continue;
+        }
+
+        let id = match vacancy_id_from_link(&item.link) {
+            Some(id) => id,
+            None => {
+                log::warn!(
+                    "Skipping RSS item with unexpected vacancy link {}",
+                    item.link
+                );
+                continue;
+            }
+        };
+
+        jobs.push(Job {
+            id,
+            name: item.title,
+            url: item.link,
+            snippet: None,
+        });
+    }
+
+    Ok(jobs)
+}
+
+async fn probe_search_access(client: &Client, base_url: &str, user_agent: &str) -> bool {
+    let request_url = match feed_request_url(base_url) {
+        Ok(url) => url,
+        Err(error) => {
+            log::warn!("Failed to build HeadHunter RSS probe URL: {error:#}");
+            return false;
+        }
+    };
+
     match client
         .get(request_url)
         .header(USER_AGENT, user_agent)
-        .header(HH_USER_AGENT_HEADER.clone(), user_agent)
         .send()
         .await
     {
         Ok(response) if response.status().is_success() => true,
         Ok(response) => {
-            log::debug!("HH proxy probe received status {}", response.status());
+            log::debug!("HH RSS probe received status {}", response.status());
             false
         }
         Err(error) => {
-            log::debug!("HH proxy probe failed: {error}");
+            log::debug!("HH RSS probe failed: {error}");
             false
         }
     }
 }
 
-async fn configured_proxy_candidates(timeout: Duration) -> Result<Vec<String>> {
+fn uses_hh_host(base_url: &str) -> bool {
+    Url::parse(base_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .is_some_and(|host| host == "hh.ru" || host.ends_with(".hh.ru"))
+}
+
+async fn configured_proxy_candidates(timeout: Duration, base_url: &str) -> Result<Vec<String>> {
     let mut seen = HashSet::new();
     let mut candidates = Vec::new();
 
@@ -463,7 +550,13 @@ async fn configured_proxy_candidates(timeout: Duration) -> Result<Vec<String>> {
                 })
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_else(|| DEFAULT_PROXY_SOURCES.to_vec());
+        .unwrap_or_else(|| {
+            if uses_hh_host(base_url) {
+                DEFAULT_PROXY_SOURCES.to_vec()
+            } else {
+                Vec::new()
+            }
+        });
 
     for source in configured_sources {
         match fetch_proxy_source_candidates(&source_client, &source).await {
@@ -533,7 +626,7 @@ impl HhClient {
         let base_url = base_url.into();
         let user_agent = configured_user_agent();
         let timeout = configured_proxy_probe_timeout()?;
-        let proxy_candidates = configured_proxy_candidates(timeout).await?;
+        let proxy_candidates = configured_proxy_candidates(timeout, &base_url).await?;
         let direct_client = build_client_with_timeout(timeout)?;
 
         if proxy_candidates.is_empty() {
@@ -563,7 +656,7 @@ impl HhClient {
                 }
             };
 
-            if probe_vacancies_access(&client, &base_url, &user_agent).await {
+            if probe_search_access(&client, &base_url, &user_agent).await {
                 log::info!("Accepted HeadHunter proxy candidate {redacted}");
                 routes.push(HhRoute {
                     client,
@@ -579,12 +672,12 @@ impl HhClient {
                 continue;
             }
 
-            log::warn!("Proxy {redacted} did not pass the HeadHunter vacancies probe");
+            log::warn!("Proxy {redacted} did not pass the HeadHunter RSS probe");
         }
 
         if routes.is_empty() {
             log::warn!(
-                "No configured proxy passed the HeadHunter vacancies probe, falling back to direct access"
+                "No configured proxy passed the HeadHunter RSS probe, falling back to direct access"
             );
         }
 
@@ -600,7 +693,7 @@ impl HhClient {
         })
     }
 
-    pub async fn fetch_jobs(&self) -> Result<Vec<Job>, reqwest::Error> {
+    pub async fn fetch_jobs(&self) -> Result<Vec<Job>> {
         let to = Utc::now();
         let from = to - chrono::Duration::minutes(45);
         self.fetch_jobs_between(from, to).await
@@ -610,7 +703,7 @@ impl HhClient {
         &self,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
-    ) -> Result<Vec<Job>, reqwest::Error> {
+    ) -> Result<Vec<Job>> {
         let mut last_error = None;
 
         for route in &self.routes {
@@ -623,7 +716,7 @@ impl HhClient {
                     return Ok(jobs);
                 }
                 Err(error) => {
-                    log::warn!("HeadHunter fetch failed via {}: {}", route.label, error);
+                    log::warn!("HeadHunter fetch failed via {}: {error:#}", route.label);
                     last_error = Some(error);
                 }
             }
@@ -637,58 +730,24 @@ impl HhClient {
         client: &Client,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
-    ) -> Result<Vec<Job>, reqwest::Error> {
-        let url = format!("{}/vacancies", self.base_url);
-        log::debug!("Requesting jobs from {url}");
-        let search_query = SEARCH_TERMS.join(" OR ");
-        let mut page = 0;
-        let mut jobs = Vec::new();
+    ) -> Result<Vec<Job>> {
+        let request_url = feed_request_url(&self.base_url)?;
+        log::debug!("Requesting jobs from {request_url}");
 
-        loop {
-            let mut request_url = Url::parse(&url).expect("HH vacancies URL must be valid");
-            request_url
-                .query_pairs_mut()
-                .append_pair("text", &search_query)
-                .append_pair("per_page", "100")
-                .append_pair("page", &page.to_string())
-                .append_pair("order_by", "publication_time")
-                .append_pair("search_field", "name")
-                .append_pair(
-                    "date_from",
-                    &from.to_rfc3339_opts(SecondsFormat::Secs, true),
-                )
-                .append_pair("date_to", &to.to_rfc3339_opts(SecondsFormat::Secs, true));
+        let body = client
+            .get(request_url)
+            .header(USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .context("failed to request HeadHunter search RSS")?
+            .error_for_status()
+            .context("HeadHunter search RSS returned an unsuccessful status")?
+            .text()
+            .await
+            .context("failed to read HeadHunter search RSS response body")?;
 
-            let response = client
-                .get(request_url)
-                .header(USER_AGENT, &self.user_agent)
-                .header(HH_USER_AGENT_HEADER.clone(), &self.user_agent)
-                .send()
-                .await?
-                .error_for_status()?
-                .json::<VacanciesResponse>()
-                .await?;
-
-            log::debug!(
-                "Fetched page {} with {} item(s) for range {}..{}",
-                page,
-                response.items.len(),
-                from,
-                to
-            );
-
-            let pages = response
-                .pages
-                .unwrap_or(u32::from(response.items.is_empty()));
-            jobs.extend(response.items);
-
-            page += 1;
-            if page >= pages.max(1) {
-                break;
-            }
-        }
-
-        log::debug!("Parsed {} jobs", jobs.len());
+        let jobs = parse_rss_jobs(&body, from, to)?;
+        log::debug!("Parsed {} jobs from HeadHunter RSS", jobs.len());
         Ok(jobs)
     }
 }
@@ -703,8 +762,10 @@ impl Default for HhClient {
 mod tests {
     use super::{
         normalize_proxy_candidate, parse_freeproxy24_candidates, parse_openproxylist_candidates,
-        parse_spys_proxy_candidates, redact_proxy_url, split_configured_values,
+        parse_rss_jobs, parse_spys_proxy_candidates, redact_proxy_url, split_configured_values,
+        vacancy_id_from_link,
     };
+    use chrono::{TimeZone, Utc};
 
     #[test]
     fn split_configured_values_supports_lines_and_commas() {
@@ -788,5 +849,40 @@ Fromat: CountryFlag IP:PORT ResponseTime CountryCode [ISP]\n\
             parsed,
             vec!["socks5://85.143.173.198:8444", "socks4://31.135.91.9:4145"]
         );
+    }
+
+    #[test]
+    fn vacancy_id_is_parsed_from_link() {
+        assert_eq!(
+            vacancy_id_from_link("https://spb.hh.ru/vacancy/132168741"),
+            Some("132168741".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_rss_jobs_filters_by_requested_window() {
+        let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <pubDate>2026-04-20T12:29:41.773+03:00</pubDate>
+      <title>Middle Backend разработчик (Rust)</title>
+      <link>https://spb.hh.ru/vacancy/132235061</link>
+    </item>
+    <item>
+      <pubDate>2026-04-15T14:43:52.856+03:00</pubDate>
+      <title>Backend-разработчик (RUST, C/C++)</title>
+      <link>https://spb.hh.ru/vacancy/132168741</link>
+    </item>
+  </channel>
+</rss>"#;
+        let from = Utc.with_ymd_and_hms(2026, 4, 16, 0, 0, 0).unwrap();
+        let to = Utc.with_ymd_and_hms(2026, 4, 20, 23, 59, 59).unwrap();
+
+        let jobs = parse_rss_jobs(body, from, to).unwrap();
+
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, "132235061");
+        assert_eq!(jobs[0].name, "Middle Backend разработчик (Rust)");
     }
 }

--- a/tests/hh_client.rs
+++ b/tests/hh_client.rs
@@ -1,21 +1,43 @@
-use chrono::{SecondsFormat, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use mockito::{Matcher, Server};
-use reqwest::StatusCode;
 use rust_hh_feed::hh::HhClient;
 
+fn rss_feed(items: &[(&str, &str, &str)]) -> String {
+    let items_xml = items
+        .iter()
+        .map(|(pub_date, title, link)| {
+            format!(
+                "<item><pubDate>{pub_date}</pubDate><title>{title}</title><link>{link}</link><guid isPermaLink=\"true\">{link}</guid></item>"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+
+    format!(
+        "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel>{items_xml}</channel></rss>"
+    )
+}
+
 #[tokio::test]
-async fn fetch_jobs_parses_mock_response() {
+async fn fetch_jobs_parses_mock_rss_response() {
     let mut server = Server::new_async().await;
-    let body = r#"{"items":[{"id":"1","name":"Rust dev","alternate_url":"http://example.com/1","snippet":{"requirement":"Rust experience"}}]}"#;
     let expected_user_agent = "rust-hh-feed/1.0 (qqrm@users.noreply.github.com)";
+    let pub_date = (Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
     let mock = server
-        .mock("GET", "/vacancies")
-        .match_query(Matcher::Any)
+        .mock("GET", "/search/vacancy/rss")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("order_by".into(), "publication_time".into()),
+            Matcher::UrlEncoded("search_field".into(), "name".into()),
+            Matcher::UrlEncoded("text".into(), "rust".into()),
+        ]))
         .match_header("user-agent", expected_user_agent)
-        .match_header("hh-user-agent", expected_user_agent)
         .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(body)
+        .with_header("content-type", "application/xml")
+        .with_body(rss_feed(&[(
+            &pub_date,
+            "Rust dev",
+            "http://example.com/vacancy/1",
+        )]))
         .create_async()
         .await;
 
@@ -26,92 +48,64 @@ async fn fetch_jobs_parses_mock_response() {
     let job = &jobs[0];
     assert_eq!(job.id, "1");
     assert_eq!(job.name, "Rust dev");
-    assert_eq!(job.url, "http://example.com/1");
-    assert_eq!(
-        job.snippet.as_ref().and_then(|s| s.requirement.as_deref()),
-        Some("Rust experience"),
-    );
+    assert_eq!(job.url, "http://example.com/vacancy/1");
+    assert!(job.snippet.is_none());
 
     mock.assert_async().await;
 }
 
 #[tokio::test]
-async fn fetch_jobs_between_requests_all_pages_for_range() {
+async fn fetch_jobs_between_filters_rss_items_by_requested_range() {
     let mut server = Server::new_async().await;
-    let from = Utc.with_ymd_and_hms(2026, 4, 3, 7, 15, 0).unwrap();
-    let to = Utc.with_ymd_and_hms(2026, 4, 3, 8, 0, 0).unwrap();
-    let from_rfc3339 = from.to_rfc3339_opts(SecondsFormat::Secs, true);
-    let to_rfc3339 = to.to_rfc3339_opts(SecondsFormat::Secs, true);
+    let from = Utc.with_ymd_and_hms(2026, 4, 16, 0, 0, 0).unwrap();
+    let to = Utc.with_ymd_and_hms(2026, 4, 20, 23, 59, 59).unwrap();
 
-    let first_page = server
-        .mock("GET", "/vacancies")
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "0".into()),
-            Matcher::UrlEncoded("per_page".into(), "100".into()),
-            Matcher::UrlEncoded("date_from".into(), from_rfc3339.clone()),
-            Matcher::UrlEncoded("date_to".into(), to_rfc3339.clone()),
-        ]))
+    let mock = server
+        .mock("GET", "/search/vacancy/rss")
+        .match_query(Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"{
-                "pages": 2,
-                "items": [
-                    {"id":"1","name":"Rust dev","alternate_url":"http://example.com/1"}
-                ]
-            }"#,
-        )
-        .create_async()
-        .await;
-
-    let second_page = server
-        .mock("GET", "/vacancies")
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "100".into()),
-            Matcher::UrlEncoded("date_from".into(), from_rfc3339),
-            Matcher::UrlEncoded("date_to".into(), to_rfc3339),
+        .with_header("content-type", "application/xml")
+        .with_body(rss_feed(&[
+            (
+                "2026-04-20T12:29:41.773+03:00",
+                "Middle Backend разработчик (Rust)",
+                "http://example.com/vacancy/132235061",
+            ),
+            (
+                "2026-04-15T14:43:52.856+03:00",
+                "Backend-разработчик (RUST, C/C++)",
+                "http://example.com/vacancy/132168741",
+            ),
         ]))
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"{
-                "pages": 2,
-                "items": [
-                    {"id":"2","name":"Rust engineer","alternate_url":"http://example.com/2"}
-                ]
-            }"#,
-        )
         .create_async()
         .await;
 
     let client = HhClient::with_base_url(server.url());
     let jobs = client.fetch_jobs_between(from, to).await.unwrap();
 
-    assert_eq!(jobs.len(), 2);
-    assert_eq!(jobs[0].id, "1");
-    assert_eq!(jobs[1].id, "2");
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "132235061");
 
-    first_page.assert_async().await;
-    second_page.assert_async().await;
+    mock.assert_async().await;
 }
 
 #[tokio::test]
 async fn fetch_jobs_fails_on_unsuccessful_status() {
     let mut server = Server::new_async().await;
     let mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(Matcher::Any)
         .with_status(403)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{"errors":[{"type":"forbidden"}]}"#)
+        .with_header("content-type", "application/xml")
+        .with_body("<rss></rss>")
         .create_async()
         .await;
 
     let client = HhClient::with_base_url(server.url());
     let error = client.fetch_jobs().await.unwrap_err();
+    let reqwest_error = error.downcast_ref::<reqwest::Error>().unwrap();
 
-    assert_eq!(error.status(), Some(StatusCode::FORBIDDEN));
+    assert_eq!(reqwest_error.status(), Some(reqwest::StatusCode::FORBIDDEN));
 
     mock.assert_async().await;
 }
@@ -120,18 +114,20 @@ async fn fetch_jobs_fails_on_unsuccessful_status() {
 async fn fetch_jobs_fails_on_invalid_success_payload() {
     let mut server = Server::new_async().await;
     let mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{"description":"unexpected payload"}"#)
+        .with_header("content-type", "application/xml")
+        .with_body("<rss><channel><item></rss>")
         .create_async()
         .await;
 
     let client = HhClient::with_base_url(server.url());
     let error = client.fetch_jobs().await.unwrap_err();
 
-    assert!(error.is_decode());
+    assert!(error
+        .to_string()
+        .contains("failed to parse HeadHunter search RSS"));
 
     mock.assert_async().await;
 }

--- a/tests/main_description.rs
+++ b/tests/main_description.rs
@@ -7,12 +7,15 @@ use tempfile::tempdir;
 #[test]
 fn main_ignores_jobs_with_rust_only_in_description() {
     let mut server = Server::new();
-    let hh_body = r#"{"items":[{"id":"1","name":"Backend dev","alternate_url":"http://example.com/1","snippet":{"requirement":"Proficiency in Rust"}}]}"#;
+    let hh_body = r#"<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0"><channel>
+  <item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Backend dev</title><link>http://example.com/vacancy/1</link></item>
+</channel></rss>"#;
     let hh_mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
+        .with_header("content-type", "application/xml")
         .with_body(hh_body)
         .create();
 

--- a/tests/main_failure.rs
+++ b/tests/main_failure.rs
@@ -6,28 +6,27 @@ use tempfile::tempdir;
 #[test]
 fn main_does_not_commit_state_after_failed_delivery() {
     let mut server = Server::new();
-    let hh_body = r#"{
-        "items": [
-            {"id":"1","name":"Rust dev","alternate_url":"http://example.com/1"},
-            {"id":"2","name":"Rust engineer","alternate_url":"http://example.com/2"}
-        ]
-    }"#;
+    let hh_body = r#"<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0"><channel>
+  <item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item>
+  <item><pubDate>2026-04-20T11:29:41.773+03:00</pubDate><title>Rust engineer</title><link>http://example.com/vacancy/2</link></item>
+</channel></rss>"#;
     let hh_mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
+        .with_header("content-type", "application/xml")
         .with_body(hh_body)
         .create();
 
     let tg_ok = server
         .mock("POST", "/bottoken/sendMessage")
-        .match_body(Matcher::Regex("http://example.com/1".into()))
+        .match_body(Matcher::Regex("http://example.com/vacancy/1".into()))
         .with_status(200)
         .create();
     let tg_fail = server
         .mock("POST", "/bottoken/sendMessage")
-        .match_body(Matcher::Regex("http://example.com/2".into()))
+        .match_body(Matcher::Regex("http://example.com/vacancy/2".into()))
         .with_status(500)
         .create();
 

--- a/tests/main_manual.rs
+++ b/tests/main_manual.rs
@@ -8,11 +8,13 @@ use tempfile::tempdir;
 fn main_manual_mocked() {
     let mut server = Server::new();
     let hh_mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body("{\"items\":[{\"id\":\"1\",\"name\":\"Rust dev\",\"alternate_url\":\"http://example.com/1\"}]}")
+        .with_header("content-type", "application/xml")
+        .with_body(
+            "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel><item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item></channel></rss>",
+        )
         .create();
 
     let tg_mock = server

--- a/tests/main_skip_duplicates.rs
+++ b/tests/main_skip_duplicates.rs
@@ -8,11 +8,13 @@ use tempfile::tempdir;
 fn main_skips_already_posted() {
     let mut server = Server::new();
     let hh_mock = server
-        .mock("GET", "/vacancies")
+        .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)
         .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body("{\"items\":[{\"id\":\"1\",\"name\":\"Rust dev\",\"alternate_url\":\"http://example.com/1\"}]}")
+        .with_header("content-type", "application/xml")
+        .with_body(
+            "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel><item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item></channel></rss>",
+        )
         .create();
 
     let tg_mock = server


### PR DESCRIPTION
## Summary
Switch the HeadHunter collector from the blocked `/vacancies` API to the public search RSS feed and restore the posting schedule.

## Problem
The HeadHunter vacancy API now returns `403 forbidden` even from a real Chrome browser on a Russian IP, so the bot cannot recover missed jobs through the old transport.

## Solution
Use `search/vacancy/rss` as the transport, parse RSS items into the existing `Job` model, probe proxies against the RSS endpoint, and only use built-in proxy discovery for real HH hosts. Restore the 20-minute `post.yml` schedule while keeping the variable gate.

## Scope
Included: RSS transport, proxy probe update, documentation/config updates, test migration, and schedule restoration.
Not included: changes to Telegram alerting or any new scraping path beyond the public RSS feed.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- Manual live verification that `https://spb.hh.ru/search/vacancy/rss?...text=rust...` returns current Rust vacancies including `132168741`.

## Risks
The RSS feed is public and currently healthy, but its retention depth is controlled by HH. Very long outage windows may still outrun the feed history.
