### PR TITLE
Restore PR gates and auto-merge flow

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -34,32 +34,55 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.workflow_run.pull_requests[0];
-            if (!pr) {
+            const {owner, repo} = context.repo;
+            const workflowRun = context.payload.workflow_run;
+
+            let prNumber = workflowRun.pull_requests[0]?.number;
+            let prData;
+
+            if (prNumber) {
+              const { data } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              prData = data;
+            } else if (workflowRun.head_branch) {
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${workflowRun.head_branch}`,
+              });
+              prData = pulls[0];
+              prNumber = prData?.number;
+            }
+
+            if (!prNumber || !prData) {
               core.setOutput('number', '');
               core.setOutput('author', '');
               core.setOutput('same_repo', 'false');
               core.setOutput('head_ref', '');
+              core.setOutput('head_sha', '');
+              core.setOutput('base_ref', '');
               return;
             }
 
-            const { data } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
             const sameRepo =
-              data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+              prData.head.repo.full_name === `${owner}/${repo}`;
 
-            core.setOutput('number', pr.number);
-            core.setOutput('author', data.user.login);
+            core.setOutput('number', prNumber);
+            core.setOutput('author', prData.user.login);
             core.setOutput('same_repo', String(sameRepo));
-            core.setOutput('head_ref', data.head.ref);
+            core.setOutput('head_ref', prData.head.ref);
+            core.setOutput('head_sha', prData.head.sha);
+            core.setOutput('base_ref', prData.base.ref);
 
       - name: Merge CI-green internal PR
         if: >
           steps.pr.outputs.number &&
           steps.pr.outputs.same_repo == 'true' &&
+          steps.pr.outputs.base_ref == 'main' &&
           (
             (
               steps.pr.outputs.author == 'dependabot[bot]' &&
@@ -70,8 +93,9 @@ jobs:
           )
         env:
           PR: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
 
-          gh pr merge "$PR" --auto --squash --delete-branch
+          gh pr merge "$PR" --auto --squash --delete-branch --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI Checks
 
 on:
   pull_request:
+  push:
+    branches:
+      - dependabot/**
 
 permissions:
   contents: read
@@ -37,7 +40,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo fmt --all
+          cargo fmt --all -- --check
           cargo clippy --quiet --all-targets --all-features -- -D warnings
           cargo machete
           cargo test --quiet

--- a/.github/workflows/pr_cleanup.yml
+++ b/.github/workflows/pr_cleanup.yml
@@ -50,6 +50,7 @@ jobs:
             }
 
       - name: Delete branch
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: dawidd6/action-delete-branch@d1efac9a6f7a9b408d4e8ff663a99c1fbac17b3f # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,21 @@
+use chrono::{Duration, Utc};
+
+pub fn recent_rfc3339(minutes_ago: i64) -> String {
+    (Utc::now() - Duration::minutes(minutes_ago)).to_rfc3339()
+}
+
+pub fn rss_feed(items: &[(&str, &str, &str)]) -> String {
+    let items_xml = items
+        .iter()
+        .map(|(pub_date, title, link)| {
+            format!(
+                "<item><pubDate>{pub_date}</pubDate><title>{title}</title><link>{link}</link><guid isPermaLink=\"true\">{link}</guid></item>"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+
+    format!(
+        "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel>{items_xml}</channel></rss>"
+    )
+}

--- a/tests/main_manual.rs
+++ b/tests/main_manual.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::Command;
 use mockito::Server;
 use serde_json::Value;
@@ -7,14 +9,17 @@ use tempfile::tempdir;
 #[test]
 fn main_manual_mocked() {
     let mut server = Server::new();
+    let pub_date = common::recent_rfc3339(5);
     let hh_mock = server
         .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)
         .with_status(200)
         .with_header("content-type", "application/xml")
-        .with_body(
-            "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel><item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item></channel></rss>",
-        )
+        .with_body(common::rss_feed(&[(
+            &pub_date,
+            "Rust dev",
+            "http://example.com/vacancy/1",
+        )]))
         .create();
 
     let tg_mock = server


### PR DESCRIPTION
## Summary
Restore GitHub PR automation so checks run reliably for Dependabot branches, auto-merge can resolve PRs from CI workflow runs, and merged-PR cleanup only deletes same-repo branches. Also stabilize the manual RSS integration test by generating a recent feed timestamp.

## Problem
Open Dependabot PRs had no check runs, `CI Checks`/`Auto merge` were not progressing merges, and the local validation baseline was red because `tests/main_manual.rs` used a stale hard-coded publication date.

## Solution
Add a `push` trigger for `dependabot/**` in `CI Checks`, turn formatting into a real gate with `cargo fmt --check`, teach `Auto merge` to find the PR by head branch when `workflow_run.pull_requests` is empty, guard the merge with `--match-head-commit`, and restrict branch cleanup to same-repo heads. Replace the stale RSS fixture in `main_manual` with a recent timestamp helper.

## Scope
Included: PR CI trigger/gate fixes, auto-merge resolution hardening, cleanup safety, and the minimum test stabilization required to pass repository validation.
Not included: repository branch protection settings, Dependabot PR rebases/recreates, or broader test refactors already in progress in the main worktree.

## Validation
- `rustup component add clippy rustfmt`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

## Risks
Existing open Dependabot PRs were created before this workflow change, so they may still need a new commit or `@dependabot rebase`/`@dependabot recreate` after this PR merges in order to pick up the new `push` trigger and reactivate checks.