### PR TITLE
Restore safe auto-merge for dependency bumps

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -37,6 +37,42 @@ jobs:
             const {owner, repo} = context.repo;
             const workflowRun = context.payload.workflow_run;
 
+            const normalizeVersion = (value) => {
+              const sanitized = value
+                .trim()
+                .replace(/^v/i, '')
+                .replace(/[),.]+$/, '');
+              const match = sanitized.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+].*)?$/);
+              if (!match) {
+                return null;
+              }
+
+              return match.slice(1, 4).map((part) => Number(part ?? '0'));
+            };
+
+            const classifyUpdate = (fromVersion, toVersion) => {
+              const from = normalizeVersion(fromVersion);
+              const to = normalizeVersion(toVersion);
+
+              if (!from || !to) {
+                return 'unknown';
+              }
+
+              if (to[0] !== from[0]) {
+                return 'major';
+              }
+
+              if (to[1] !== from[1]) {
+                return 'minor';
+              }
+
+              if (to[2] !== from[2]) {
+                return 'patch';
+              }
+
+              return 'none';
+            };
+
             let prNumber = workflowRun.pull_requests[0]?.number;
             let prData;
 
@@ -64,33 +100,73 @@ jobs:
               core.setOutput('same_repo', 'false');
               core.setOutput('head_ref', '');
               core.setOutput('head_sha', '');
+              core.setOutput('should_merge', 'false');
+              core.setOutput('reason', 'no-associated-pr');
               core.setOutput('base_ref', '');
               return;
             }
 
             const sameRepo =
               prData.head.repo.full_name === `${owner}/${repo}`;
+            const author = prData.user.login;
+            const headRef = prData.head.ref;
+            const headSha = prData.head.sha;
+            const isDependabot =
+              (author === 'dependabot[bot]' || author === 'app/dependabot') &&
+              headRef.startsWith('dependabot/');
+
+            const updates = [
+              ...(prData.body ?? '').matchAll(
+                /(?:Bumps \[[^\]]+\]\([^)]+\)|Updates `[^`]+`) from ([^ \n]+) to ([^ \n]+)/g
+              ),
+            ];
+            const updateKinds = updates.map(([, fromVersion, toVersion]) =>
+              classifyUpdate(fromVersion, toVersion)
+            );
+            const safeDependabot =
+              isDependabot &&
+              updateKinds.length > 0 &&
+              updateKinds.every((kind) => kind === 'minor' || kind === 'patch');
+            const trustedInternalAuthor =
+              author === 'qqrm' || author === 'codex-bot';
+            const shouldMerge =
+              sameRepo && (safeDependabot || trustedInternalAuthor);
+
+            let reason = 'not-eligible';
+            if (safeDependabot) {
+              reason = 'dependabot-minor-or-patch';
+            } else if (trustedInternalAuthor) {
+              reason = 'trusted-internal-author';
+            } else if (isDependabot && updateKinds.length === 0) {
+              reason = 'dependabot-update-type-undetected';
+            } else if (isDependabot) {
+              reason = `dependabot-${updateKinds.join(',') || 'unknown'}`;
+            }
 
             core.setOutput('number', prNumber);
-            core.setOutput('author', prData.user.login);
+            core.setOutput('author', author);
             core.setOutput('same_repo', String(sameRepo));
-            core.setOutput('head_ref', prData.head.ref);
-            core.setOutput('head_sha', prData.head.sha);
+            core.setOutput('head_ref', headRef);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('should_merge', String(shouldMerge));
+            core.setOutput('reason', reason);
             core.setOutput('base_ref', prData.base.ref);
+
+      - name: Report skipped auto-merge
+        if: >
+          steps.pr.outputs.number &&
+          steps.pr.outputs.should_merge != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Skipping auto-merge: ${{ steps.pr.outputs.reason }}"
 
       - name: Merge CI-green internal PR
         if: >
           steps.pr.outputs.number &&
-          steps.pr.outputs.same_repo == 'true' &&
+          steps.pr.outputs.should_merge == 'true' &&
           steps.pr.outputs.base_ref == 'main' &&
-          (
-            (
-              steps.pr.outputs.author == 'dependabot[bot]' &&
-              startsWith(steps.pr.outputs.head_ref, 'dependabot/')
-            ) ||
-            steps.pr.outputs.author == 'qqrm' ||
-            steps.pr.outputs.author == 'codex-bot'
-          )
         env:
           PR: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test:
+    name: CI Checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/tests/main_description.rs
+++ b/tests/main_description.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::Command;
 use mockito::Server;
 use serde_json::Value;
@@ -7,10 +9,8 @@ use tempfile::tempdir;
 #[test]
 fn main_ignores_jobs_with_rust_only_in_description() {
     let mut server = Server::new();
-    let hh_body = r#"<?xml version='1.0' encoding='utf-8'?>
-<rss version="2.0"><channel>
-  <item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Backend dev</title><link>http://example.com/vacancy/1</link></item>
-</channel></rss>"#;
+    let pub_date = common::recent_rfc3339(5);
+    let hh_body = common::rss_feed(&[(&pub_date, "Backend dev", "http://example.com/vacancy/1")]);
     let hh_mock = server
         .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)

--- a/tests/main_failure.rs
+++ b/tests/main_failure.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::Command;
 use mockito::{Matcher, Server};
 use std::fs;
@@ -6,11 +8,16 @@ use tempfile::tempdir;
 #[test]
 fn main_does_not_commit_state_after_failed_delivery() {
     let mut server = Server::new();
-    let hh_body = r#"<?xml version='1.0' encoding='utf-8'?>
-<rss version="2.0"><channel>
-  <item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item>
-  <item><pubDate>2026-04-20T11:29:41.773+03:00</pubDate><title>Rust engineer</title><link>http://example.com/vacancy/2</link></item>
-</channel></rss>"#;
+    let first_pub_date = common::recent_rfc3339(5);
+    let second_pub_date = common::recent_rfc3339(65);
+    let hh_body = common::rss_feed(&[
+        (&first_pub_date, "Rust dev", "http://example.com/vacancy/1"),
+        (
+            &second_pub_date,
+            "Rust engineer",
+            "http://example.com/vacancy/2",
+        ),
+    ]);
     let hh_mock = server
         .mock("GET", "/search/vacancy/rss")
         .match_query(Matcher::Any)

--- a/tests/main_skip_duplicates.rs
+++ b/tests/main_skip_duplicates.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::Command;
 use mockito::Server;
 use serde_json::Value;
@@ -7,14 +9,17 @@ use tempfile::tempdir;
 #[test]
 fn main_skips_already_posted() {
     let mut server = Server::new();
+    let pub_date = common::recent_rfc3339(5);
     let hh_mock = server
         .mock("GET", "/search/vacancy/rss")
         .match_query(mockito::Matcher::Any)
         .with_status(200)
         .with_header("content-type", "application/xml")
-        .with_body(
-            "<?xml version='1.0' encoding='utf-8'?><rss version=\"2.0\"><channel><item><pubDate>2026-04-20T12:29:41.773+03:00</pubDate><title>Rust dev</title><link>http://example.com/vacancy/1</link></item></channel></rss>",
-        )
+        .with_body(common::rss_feed(&[(
+            &pub_date,
+            "Rust dev",
+            "http://example.com/vacancy/1",
+        )]))
         .create();
 
     let tg_mock = server


### PR DESCRIPTION
## Summary
Restore the repository auto-merge flow so CI-green Dependabot dependency bumps can merge automatically again, while limiting bot auto-merge to minor and patch updates only.

## Problem
Open Dependabot PRs were staying blocked after green CI because the required `CI Checks` gate did not match the published job name, and the auto-merge workflow still relied on the old Dependabot login. The remaining date-sensitive integration-style tests also still used stale hard-coded timestamps, which can break CI as the fetch window moves forward.

## Solution
Add an explicit `CI Checks` job name so branch protection sees the required gate, keep the existing workflow-run based merge flow, and extend it to recognize the current `app/dependabot` author while parsing the PR body to auto-merge only minor and patch bumps. Also add a skip reason to the workflow logs for ineligible bot PRs. Update the remaining main-path tests to build fresh RSS fixtures through the shared helper so the suite stays green as time moves on.

## Scope
Included:
- safe auto-merge eligibility for Dependabot minor and patch updates
- required CI gate name alignment with branch protection
- stabilization of the remaining hard-coded-date tests

Not included:
- auto-merging major dependency bumps
- changes to repository-level branch protection settings

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

## Risks
Dependabot auto-merge eligibility is inferred from the standard PR body text (`Bumps ... from ... to ...` / `Updates ... from ... to ...`). If GitHub changes that format, the workflow will now skip auto-merge and log the reason instead of merging unsafely.